### PR TITLE
chore(nft-react-hooks): adds shield badges on readme

### DIFF
--- a/packages/libs/ui/nft-react-hooks/README.md
+++ b/packages/libs/ui/nft-react-hooks/README.md
@@ -1,4 +1,10 @@
-
+![npm peer dependency version](https://img.shields.io/npm/dependency-version/@quicknode/icy-nft-hooks/peer/react)
+![npm](https://img.shields.io/npm/dm/@quicknode/icy-nft-hooks)
+![npm](https://img.shields.io/npm/v/@quicknode/icy-nft-hooks?color=g)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g)
+![NPM](https://img.shields.io/npm/l/@quicknode/icy-nft-hooks?color=g)
+![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g)
+![Discord](https://img.shields.io/discord/880505845090250794?color=g)
 
 # Icy NFT hooks
 


### PR DESCRIPTION
## Summary

Adds shields to nft-react-hooks readme to be included in npm on next release
<img width="706" alt="image" src="https://user-images.githubusercontent.com/40798232/183114932-caf3b2bc-767e-46dc-9493-2fc592de23bd.png">