### PR TITLE
Fix getContractEventLogs docs

### DIFF
--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -193,7 +193,6 @@ const client = new QuickNodeSDK();
 client.nft
   .getContractEventLogs({
     address: '0x60E4d786628Fea6478F785A6d7e704777c86a7c6',
-    tokenId: '100',
     types: ['TRANSFER', 'ORDER'],
   })
   .then((response) => console.log(response));

--- a/packages/libs/api/sdk/package.json
+++ b/packages/libs/api/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/api/sdk"
   },
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "main": "./src/index.js",
   "module": "./src/index.esm.js",
   "types": "./src/index.d.ts",


### PR DESCRIPTION
removed an extra argument in the example that doesn't belong 🙃 