### PR TITLE
Normalize addresses

### DIFF
--- a/packages/libs/api/sdk/recordings/query-NFTByWalletAndContract-iterate_1229709146/recording.har
+++ b/packages/libs/api/sdk/recordings/query-NFTByWalletAndContract-iterate_1229709146/recording.har
@@ -8,162 +8,7 @@
     },
     "entries": [
       {
-        "_id": "9dca27b02c03f8f70b3e124aa6a5d473",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1044,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1044"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "graphql.icy.tools"
-            }
-          ],
-          "headersSize": 261,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"first\":2,\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
-          },
-          "queryString": [],
-          "url": "https://graphql.icy.tools/graphql"
-        },
-        "response": {
-          "bodySize": 708,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json; charset=utf-8",
-            "size": 708,
-            "text": "[\"H4sIAAAAAAAAA92WS2vbQBDH7/0URmdj7UP7kKGHxPiQHtxQCo5bQtjHyFYia4123dgYf/eu7BhKlEMLfdgFHVY7O/P/zSz82V1iVVDJcJc8q6qC0K6g9hO1hGSY6DIYV9arslEBBhAWST9R1jbgfYyiDaY5kaBzJbmRREiVMc2LguSUGSEo0kwqwwWLacE9xbpt+ZWaw01duHa9UH4Cm3Abt5JhaNbQj+p2tG68a6LC7O7DdnZXPWrC1l+mE6Sm+frj4/h9rPfwELYrqI+ct6eS+5hv5xB1vu6S2lloRQ7SNzaew4TImFsu1enMuqni/iKElR+m6TEwKM02OFf5wbNrnqDxAwvf0o1PjYsjMqF0tU/RhgHOUC6sigPQOTYZZRlEAWQLrRA2XAIFjGh6bD2lyLKMa4E5ARAm51RlBWLYKEu11fZ1U58P2C1RbOtXSP3yUkiX9lJIq/mlkG6qf0h630+Mq0OjzMFJfvQKbTKjEFgleCaUVFoYgjg2BDCWKn455QWmbXm/XWrX9nt9NRvF/xeha9eA7V2toDdTZhF6o2qtX8OMP40EwaMTw/7N8IG4Ezvsju3LwLvmQQnDv808fnYap0uRPKcy50xQXBSFYFjSAmuZC0wyGS/4z5nH2ZJ2zONsSTvmcbakHfP4m6T/iXncvxWKRevjVDup0+PDa7/fv/sOCenbZY4JAAA=\"]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 25 Oct 2022 03:29:02 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "Express"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "x-ratelimit-rpslimit",
-              "value": "4840"
-            },
-            {
-              "name": "x-ratelimit-rpsremaining",
-              "value": "4839"
-            },
-            {
-              "name": "x-ratelimit-rpsreset",
-              "value": "1666668543"
-            },
-            {
-              "name": "x-ratelimit-rpmlimit",
-              "value": "60000"
-            },
-            {
-              "name": "x-ratelimit-rpmremaining",
-              "value": "59999"
-            },
-            {
-              "name": "x-ratelimit-rpmreset",
-              "value": "1666668543"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"98e-dTKVG0lNi1xkby30O5xjB7tHH6A\""
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "75f7dd974914c461-EWR"
-            }
-          ],
-          "headersSize": 561,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-10-25T03:29:02.355Z",
-        "time": 169,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 169
-        }
-      },
-      {
-        "_id": "18bb26524d6e622ce68125ca75b5c848",
+        "_id": "5beb7977b7dfe3fbc5ecc783a7fc8e92",
         "_order": 0,
         "cache": {},
         "request": {
@@ -211,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"first\":2,\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"first\":2,\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -228,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 25 Oct 2022 03:29:02 GMT"
+              "value": "Wed, 26 Oct 2022 13:42:30 GMT"
             },
             {
               "name": "content-type",
@@ -264,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666668543"
+              "value": "1666791751"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -276,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666668543"
+              "value": "1666791751"
             },
             {
               "name": "etag",
@@ -296,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f7dd985ed48ce6-EWR"
+              "value": "76039d9668dceff5-EWR"
             }
           ],
           "headersSize": 561,
@@ -305,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-25T03:29:02.538Z",
-        "time": 128,
+        "startedDateTime": "2022-10-26T13:42:30.035Z",
+        "time": 125,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 128
+          "wait": 125
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-NFTbyWalletAndContract-base_3002657573/recording.har
+++ b/packages/libs/api/sdk/recordings/query-NFTbyWalletAndContract-base_3002657573/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "9dca27b02c03f8f70b3e124aa6a5d473",
+        "_id": "ca0e9f8dfc45bd8ebc9b438f8056eabb",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"first\":2,\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"first\":2,\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 25 Oct 2022 03:11:30 GMT"
+              "value": "Wed, 26 Oct 2022 13:42:29 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666667491"
+              "value": "1666791750"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666667491"
+              "value": "1666791750"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f7c3e4b90418b1-EWR"
+              "value": "76039d945ea48cca-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-25T03:11:29.931Z",
-        "time": 129,
+        "startedDateTime": "2022-10-26T13:42:29.671Z",
+        "time": 193,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 129
+          "wait": 193
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-NFTbyWalletAndContract-multiple_2201445956/recording.har
+++ b/packages/libs/api/sdk/recordings/query-NFTbyWalletAndContract-multiple_2201445956/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "36464e0c798c88c8705370a0ee71eff4",
+        "_id": "947b746685ed3944721c111496ff7f65",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"first\":2,\"filter\":{\"contractAddressIn\":[\"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623\",\"0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"first\":2,\"address\":\"0x13928eb9a86c8278a45b6ff2935c7730b58ac675\",\"filter\":{\"contractAddressIn\":[\"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623\",\"0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 25 Oct 2022 03:21:30 GMT"
+              "value": "Wed, 26 Oct 2022 13:42:30 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666668090"
+              "value": "1666791751"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "22989"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666668090"
+              "value": "1666791751"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f7d28a5c0d32fc-EWR"
+              "value": "76039d956f1a9e17-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-25T03:21:29.746Z",
-        "time": 131,
+        "startedDateTime": "2022-10-26T13:42:29.882Z",
+        "time": 137,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 131
+          "wait": 137
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getByWalletAndContract-null_552913909/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getByWalletAndContract-null_552913909/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "a4c6d95a0b2424d716d6738d2727647f",
+        "_id": "66c183067e27704c18f9c82783481064",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"first\":2,\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTsWalletAndContract\",\"variables\":{\"first\":2,\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"filter\":{\"contractAddressIn\":[\"0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d\"]}},\"query\":\"query NFTsWalletAndContract($filter: TokensFilterInputType, $address: String, $first: Int, $after: String) {\\n  wallet(address: $address) {\\n    ensName\\n    address\\n    tokens(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              ... on ERC721Contract {\\n                symbol\\n                name\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 25 Oct 2022 03:32:26 GMT"
+              "value": "Wed, 26 Oct 2022 13:42:30 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666668747"
+              "value": "1666791751"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666668747"
+              "value": "1666791751"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f7e2912b6d8c57-EWR"
+              "value": "76039d973e3419df-EWR"
             }
           ],
           "headersSize": 560,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-25T03:32:26.125Z",
-        "time": 180,
+        "startedDateTime": "2022-10-26T13:42:30.174Z",
+        "time": 534,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 180
+          "wait": 534
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getCollectionDetails-base_2966801750/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getCollectionDetails-base_2966801750/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "759bb87585bb26747d8aedc3b698d042",
+        "_id": "4f72e55f46da3e4508958e7a5692471c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,24 +56,24 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"CollectionDetails\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\"},\"query\":\"query CollectionDetails($address: String!) {\\n  contract(address: $address) {\\n    ... on ERC721Contract {\\n      address\\n      isVerified\\n      tokenStandard\\n      attributes {\\n        name\\n        rarity\\n        value\\n        valueCount\\n        __typename\\n      }\\n      circulatingSupply\\n      name\\n      stats {\\n        average\\n        ceiling\\n        floor\\n        totalSales\\n        volume\\n        __typename\\n      }\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"CollectionDetails\",\"variables\":{\"address\":\"0x2106c00ac7da0a3430ae667879139e832307aeaa\"},\"query\":\"query CollectionDetails($address: String!) {\\n  contract(address: $address) {\\n    ... on ERC721Contract {\\n      address\\n      isVerified\\n      tokenStandard\\n      attributes {\\n        name\\n        rarity\\n        value\\n        valueCount\\n        __typename\\n      }\\n      circulatingSupply\\n      name\\n      stats {\\n        average\\n        ceiling\\n        floor\\n        totalSales\\n        volume\\n        __typename\\n      }\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
         },
         "response": {
-          "bodySize": 3078,
+          "bodySize": 3114,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 3078,
-            "text": "[\"H4sIAAAAAAAAA71bYW/bOBL9fr9C0OecQUq2ZOVb7Wua3Wu72bjb3cPhsGBkJiWiiD5aSusr8t9v6CTmiKSMEvQdsA9pN3JeSc68eTNivqdr1rH0/Htay7ZTrO70n9l6rfh2m56n5FtGSVETwupyzQjLpzlhvCjKeVnRvOLzPMtJyThj6Vkqtp+5EreCr9PzW9Zs+VnayXverjrWrpmC/5u+vV6WGYVnWdcpcdN3HFj++T1t2QOHb19ytr7jTMEDiinR7dJzMsmmhAxwlj6yptfPr+Cf/PWGK7VLloqzh/TlW0vZt7CSbHqW/vlnt9vwl5+/fFnkm1f29OnsGDmdkBmhBob5SigGHx/y7Z/4ccK3O1g9XiktCMFAK/3I1Xpn0xUhbG/qGs5Uqt1wcwnQvMLQ/YM3jfyarO6F6uxNJSGsH2TffRkwliUhBoby76K9t1eov//jXAtW3/+VeZZJJzPYUIwB7Z29r7OgJfqDFlgMUMSK5pGr5J1Qjdh+sbc2KHx8B3pspW+Ukl/jlmpFLJ3kGaEYaKEN5xvP3uZZBGGmxSAzQPnYq03Dkyumul3yrmHb7f6Dg90NkwN/vlAQIAPDv2xkv7bXegI+AlliYPjeKc5bb34GpcwI6UAVADk6V58khGXplv8w2/KLrGUDSptc9JBk/zfez6wVTcOSJVQuW5SCWCEU/zOkrYDKwFB+4qxJgC5ZbZi6t4O3CmL1S0MFIXuAkzq+g4VHoyvobA5CZIBWvGQO32weoQ75RB8iBlqk4h0ow1XDn8MAs8Kj0XpfgdYaGN73AuxJZ4dQdQKhL3NCEdC+/k22fZf81N5C4rCbxnEpZR4TwfkkK0hugDSJNeybvdT9E5Gbm4PYGhjCBRS0NrlkQtmkQcrrepTpnJAB0OYK9iBbW+qnQXE7YsVAEDBw9II3Sn6HaurWtLiFEtACDFTAl/JRrJMPbHtvB2+8OfKbzp/ZhrXcSc8ww+nVoBxyxABFrJQO3f6B2LMsKVTrA3A9Y9sOnkkWvHEKN43nncGWItBB3G64nSez6KoClA==\",\"sEQDlJys84bsLGiZ3viZQW9kgCj7trX1Z3aKJgkkwMDwXfO1v0U6gRoMTDwqKM/G70r2td090JjmM9OEmQEyfGAPlNhyW/KySL4CvADCFDO2d34HXwRtrFcKoHGgBpbEXrqOJHqGQLQDIgg4KfeV+iPf2rRhPsjLOiZBOmj97ecpBAgqNDlgSOqL2Wm885oBlQF2fPJ2/w+0tzboQG33A352BvloMJhGMWWHLDwSvcIpFGYDw/dTzWvP1GsaVKDdBmXkCPcJMtqfnOAgM2hxDZCqN+C3+NjI5ATtLh00RgPj9azwnklf0B67gz4ozwNYc5MH13XRKKdH9SCBIqCwvWBukaYkel9Baiks7gBkghQ09WsBPed4j5IFaZGbpdCbUAx0pGwtJPwg8eiSxrYqdEJB3w3ssn2hpDMQo/E1jcICEfDZql50yUJ+bRzaaF9E9ZCTIiDeN2tHlmjYdNMZNYIqUATc74pH5vS4QXo0ogvjWXrVQKfSOVkTM9ukkymkJoah+yN5eXg4XgzKUb/mjveczxG7ZFvRSo8xCus8/WELDYrBUHS9mRI5eTvyIula1rbgnsD4FeDdDQzb2+ZR2KdZxPoEqn0CRcDp2N5xRwHCfELQ1OtaPrA2aublpZtDhCLgfNTmZDRW5ydoc2kOAoCA9aev74+UsqBxgiMKYwVlIZXTkgXWkpHRxcj7uQV88XqhsJd0rjMZD9vn9sgzggqMXXeEWRQkx3AiyR37w3NxlmTcgb1t+B1ru+QCGqStcGpZmBfzd70jVmyhmLATNdB7jUQRpCgCteLINxgq4ysK9CwUAW3xr71onYWSIIl3XPy0gAbpAGThN0IxW26n8d5y3G79osDDc+/4IvpNA9G+hGCgpX5e2csMilU7STI92ssQpo7+iK5r3MFQ2JTPu7vj/vK9lBvh2q8wi+nOv2CFBobtkm02zivHMO2xNTbTR5ghoG19J5t18onzzums444SzAFUSQTq6p0+UtslxFXLChIfAen6y42WYxcE4BPxyTLuUT6vkmunZIdZE33D5U7BJ9eIc6q9ydQAUe49vJ2hUYYkn8xykhvg90XS1rz992NK5rg1MBcDgPdeOKYr2tyC8wIhQMBdtWgaKGDJaqfgi8NNo25IwaqhSGMY4g/9tmP1F3e1QRV7JIpgg6cGiPVntrYZpydoHqBqkgMsnfcP+4qgjR1ZJvBNDYbGzxlqxr+7HtzfGcwQFrL/d8+dt4CnWGMGazMYdNb2EsNmXq4HGvcGF/JbMjbNjB5d0EkBJcVgOD24lKp11L2IFCPo4imCx797QoiG9fXuG3qoYgRhMMgU7Q2UtIX7CiCskB27NwnCi4Ff0m24crt8eOoU8QvW3GCoDU4Ax79PHm9WlvqGSVSfMia2cxDZA5AK7S9jOWob1NdbN92yalLmWYVgd9gL6V5yq8JuCbk3QyFaDOyx4lEblkc195mmzgzsvfXf6Qvj9L+mm4EEYhjm31pRgyTZxxokDWOpAkQH2HbXyZWYlgW0qAINMhjmCZzkWo+pbSkK2lhb//JJVZAcAW3qe5Y0+j/bdFYneLMxfrluwW52Gz0j8l7BiLtaB90D7KyBo/V28xA5BStLkhsgbe+Yqn0jsLBRX+AM98I1fGHdkdNi53ByBihaeyVk7wwRwi5+BU38n2+XeFxJmD3wB2sOhgTDbXp9oZoHMXuCB9prA7S5TMFHnFawjH2dUup7gyU5wCyz7ZvGNtFRSve/pPId4TybzOfz7IDqCJ9+JEZR5+Ukp/PygOwYV5kHN5ZeI1kVk4pUxQHHNlQ/EuF29NllcCivyI+fXZDA2A==\",\"SaC5qI6PVxznim/SS/07YiUxOEr4I6/4/3WW1kLVfcM60d6Bqd80+rwqXbZfPqXHn7tk7xR1kmw7Bl/1bwk+csXuDtw1F3oo8vrX20ZK9fqXTnasWTE9uD2Hw32UTa9/9Ng5r/YUT8C1e7iRjfapv3z87VNqPf78y4SvH0qfnp7+8l/BJcqy0DgAAA==\"]"
+            "size": 3114,
+            "text": "[\"H4sIAAAAAAAAA71bUXPbuBF+76/g8NnVACRFin6LdLFzbZJzrVx6N53ODUzBNkY0oUKkHTXj/96lbQlLANQEhdqZ+ybxGfJ6gd1vv10g3+MVa1l8/j2uZNMqVrX939lqpfh2G5/H5FtCSV4RwqpixQhLs5QwnufFrChpWvJZmqSkYJyx+CwW269ciVvBV/H5Lau3/Cxu5Zo3y5Y1K6bg/8bvrxdFQmEta1slbrqWg5V/fI8b9sDh2x84W91xpmCBYkq0u/icTJKMkAHO4kdWd/36JfzKTzdcqV20UJw9xG/fWsiuAU+S7Cz+4492t+FvP3/x5uS7vfX4+eyYcTohU0I1tOUroRh8fGjvZcWPG3y/A++xpzQnBAN5+pmr1c40l/tYe1dVcKZS7YabS8DMHtrc77yu5VO0XAvVmptKfKzOWbX+M3OYppMpJVRD2/6raO5MT/vvB50keDoFDw9AMSTqR66iS6Fqsb03nfU6UNcWg59wmBja9Dul5JPlqtf+GjFEJ2lCKAZytOZ849jbNAkPIwp5qaFtLmrZrUyDXlnptkcKiNcDtL1LxXnjDNviBEYHyQJI0ea6MsUvUbb8h60t7mUlayCg6KKDSP+/2f3KGlHXLFoAoZts5GX1smb/HpotwZSGNvmFszoCc9Fyw9R6axgtg2OXTkoI2QMQw3dqU3NnLMHS8GiapoRoaLs/CbbhyrDYL/ivSSGZ0IIkCDhuwUslttxMUlgWcp7JZFC0rV11BlDmtavOcj2dAcdqoDhaMOsUp7OATU0nfWpgICcVb9tddFXz1+TCVmFpcCkroYxoaLsfBWih1tzX8gQ1rEgJRUD7+pNsujb6ubkFOmI3tSWJCq/IdbqbQgxpaNNzqJ5N9IEJM1tSrwrzSXbt/cBgNiNkgEF2PsjGzJbMK5JGlBgQHwaOJ9Gso79D6TbpL/GiP9tRApyHgdTCQj6KVfSJbddmOIUrMbfm/AvbsIZbCeOnN917W1BQCQfgOsq2LayJ5ry2BIOX5BzheLCngSKXtc7zPIHMnULfoIFMdk0=\",\"YzLD9AQNxEDaIi56VWJXsqtMTU1DmqSk1/GJhlVZrhgwYAT1aLvldrp4mXbvL6SJhsmDn/nWjKNpeMKMhe81X430LacIXmBbcsDQqOtYg6s37C2Y0sD1VN6+/ILm1nrxvKlRQC1AU48wGCwwZUYPLAn2MIOo0dD2fq545RhgZF6xY4vqkSN8qSejmvoEB5lAW6aBSKiG2snHeu0TtGh0IOYHRbSP2+XaMbTx2mN7ZgNVbACj4X6wKygNqtq0b34pAgrbC2bXFEqC95VOEgrOHYAKqIJGdCWAd8cVYOLFRXaWJjnYREBHylZCwg8Sj7ZRr9Lm7CUo9BAaZmW7UNKapFAvGeg2Cg4i4LNVnWijuXyqLbPBZZz2VZUiILvvVhYtUb86as2ogBUoAu4mxCOzOogTCMAjWXpVg+psrazxylHLwwxSE0Ob+y16WzwciXnlqJtzx/uH14hdsK1oJPRL1pzqBAPABMgWIzOJ1zEeCypuaV9kUgzkL6vZN1Pspn71xZmd0IFSBBS4l1JanQv160PdfJAADxww3FQnBQWO4Y5ctlzLyqxkwRcsZJJD36Chrb2vH4WZJnmoAKO9AKMImOeaO25Rq58A8xrWXMsH1gSNapzmZpD6CJjoetU3SgKzE5AATYFZETCxd9X6iEYIGW+OV+q5VNZg07NIj8wToGppYH3bcafILLy4x5Z842H72nc65jSesWvza56TFMOKJHuEC+uCM3RMas4VE2a+eGrLkcOETEGgxnG65jSFV7K4L5ahhCCgE/1bJxrLUeLFtFaXkuVQkg9ALcpGKGayXnaCQxyVk78o6FG4g4A8ReXIzAISEgO5+nVpuhl4wzEFeY6QWTQg2ra2Z1B+Qzfn7o7r549SboQtL/0ktDVyg+xPNLS1D2yzsW5x/CjApLqkP8IEAW3rpaxX0RfOW2tyEHaUUKOhWCEgCnhf8zvWQN/Vf2kU67CiVULiIyB6fXt8cWySCZ8IT5ZxqfB1GV1bldNPIfQPP+4UfHKFbGb9Q4FMw2hRzAT1eylgXdBNYVcx8OWGNEkvDR0mjpdofVsPdtfCEj/BIhMUEDABAh4biLqGChYtdwr+sGxTL2ZwCBOo0hja8Kdu27Lq3vbWq2SPhBFo6ewAfIW0Mu1lfu9p3D0KgUqyh0Hz7llm7v1IyuEkAfbTMJS8NbQNnyAM3tQMZiRz2f2r49YN2SmcTKByagwaXNNFv5merYHGtcGF/BaNTWuDRzN0kkNJ0Rg28R+kaix2z71Ki81F0ExThMSuZ44Qon7ttX2bPNrpgnC/gYI2ty84/BreI48JBy8nkb7tNlzZfTY9SX4mCYTsAUbfYAVvyEARJBhUFA3sYHPnvuvMg9o/aFCgmdawI+iiq+63wprWktAZOPBQBvxzwOCy4ck8ySLwqUcxAxsaw2eoa1PcFl7OjYQNiINMA9P6yw22GTh+6sB+DwpyRMOcCR/VmGn48CsbFOrBWPjXRlTAfVa5PkVigqEDTF1tJWZIbwSkVwLZaQzvxmBXV/2832Q9r401gzadlDlJEdCmfmRR3f9nitvyBFdEkI4UAW3snN3sNv1MyPncwy9F7TkUpGWKgcivZapyjaH88tRzjnphyz2/1sgi9zQliQaKoE4J2VnMnoY/qRubur9M9lySxE8buAMoBTWCYXe8rvBJvSw7wgc6Pw20uUzBR6w20C9ajdfTSQnRmpQI5qB2Lu13r6VfuDrGF6Ov+N6kl8k/4Q9txwd8ryEUOt5zGC36x2YFOUDLvKara7M1CXpl9r805cqNWTKZTWfJAcfs9UtOIprLfDKblfkB5RGj/ZKAvA==\",\"6PezgI3aY3Z8P4Omeb2tvD+zPY7bCppWzopJUs6KPdJjx1b43Xc7pU3vG4Vf+oDjvv3ApOWfZ3ElVNXVrBXNHbRLm7oPjbKXKG+f6mfKu+iFvvoc2bYM/uz/leAjV+zuYLvioh807b+8raVU+y9a2bJ6yfpp+Dlwz6Osu/5Hj9HQ8sXEM9jaPdzIuifPXz7/+iU2lr/+Y8L9h+Ln5+c//Qc3XTtu0DgAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 01:18:12 GMT"
+              "value": "Wed, 26 Oct 2022 00:13:27 GMT"
             },
             {
               "name": "content-type",
@@ -105,11 +105,11 @@
             },
             {
               "name": "x-ratelimit-rpsremaining",
-              "value": "2634"
+              "value": "4839"
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666142293"
+              "value": "1666743208"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,15 +117,15 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "722"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666142293"
+              "value": "1666743208"
             },
             {
               "name": "etag",
-              "value": "W/\"38d0-YSqkXXFTSrJ6VIlCEwbxd6YlJeM\""
+              "value": "W/\"38d0-XvFmtdtueJSYptsV4OnuUPn6usg\""
             },
             {
               "name": "content-encoding",
@@ -141,17 +141,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "75c5adad0cfee6fc-EWR"
+              "value": "75fefc78faab335a-EWR"
             }
           ],
-          "headersSize": 560,
+          "headersSize": 562,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T01:18:11.908Z",
-        "time": 130,
+        "startedDateTime": "2022-10-26T00:13:27.667Z",
+        "time": 204,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 130
+          "wait": 204
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getContractEventLogs-alltypes_3032705298/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getContractEventLogs-alltypes_3032705298/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4ba7868e0348552706a3257cfc786997",
+        "_id": "df40509ebfd9f647b5e98f4f67dfd7eb",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,24 +56,24 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"first\":2,\"filter\":{\"typeIn\":[\"MINT\",\"ORDER\",\"TRANSFER\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"MINT\",\"ORDER\",\"TRANSFER\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
         },
         "response": {
-          "bodySize": 740,
+          "bodySize": 796,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 740,
-            "text": "[\"H4sIAAAAAAAAA8WR22obMRCG7/sYe52UkVbSSIZeBOPSlOKG1JBDKWGkGTkn74bdNSQEv3u1SQNpXNpcBAq6GGb0/3P47iumgarJfZXaZugoDWNMzJ30fTWp4NaBGEbvnPZZyBn0Gb0lxygIBhGTd4TJVTvVdbvsR/kNLWW/ye0Yn1M/l9vhoKSqydCtZaeShqfrrm+74n9y/Pnu5Pj6Mmq7Pj2aAx2F9dfL2YfidnY23N1IQ6sirA6eLDdFz0spfb7fV03LMjaJ1226mq9XUYqnsl55E8JONeqLdnG4N//2cXZYPHPXrvaeLZddiswcksqMlhAdhBqp1pAVE2RKSqyPoUiH9rmQ2XnU1qccXU0e0WDtRwupU1K1YFCAoMerSD9crGgQnrZNvuhWwnvlyJUGrXcV7GqzUGai3MSG9wBwOrbqqOkLiou2+UT9+SMGJ4aMD7XPgKiJXAlCsmBSmc9GZ8si4kLtODAQG5eITG08S4xRy8MGV9K8Eerf4MwOp6jV9Ml186vVPpdarYL68//FwzibF7XFuHuW7ku73KqV3KywL/m/oq/1q9BHjcFqcEbFaKHs6NlFUZoxgJRrC0Dxki30nsloUhglieYQFGoGkwsAF5OhqAOZoDO8Fj3of6CPqYyZvWbRCaNLVtAyezu+WqGxxlIOGAo8hmjriD4pMMqDEgjG/S/0aJR5c/Q/tguleyMPJ9uSvRxvs3n3E6glA7LyBAAA\"]"
+            "size": 796,
+            "text": "[\"H4sIAAAAAAAAA8WTW2sbMRBG3/sz9tkpo7tk6INxtzSlOMEx5FJKGEkjx7G9a3bXkBD836t1m5LGIaFQ6NMKifONZo72oYjYYTF8KEJddQ2Grl9jjA21bTEs4E4DyWis1twmQi2NTcYq1NGQAWmMCVajCboYFKt63vb4Bud0XKW6X99gO6G77jRvFcOu2dKgoCqOt01bNzn/8uLL/eXF6tZztb06nwCeu+3Jbfkhp11fd/cbqnCdweL0MXKX+TinXOfbQ1HVkfoiflWH5WS79pQzmbKCS+UGRc9ndjYdTc4+ldOcmZp6PXrSXICYmI2i/yapLKDTgSFPIHVwMQQ0iLnNjHb1U9ByxTMarecOlIkMEwnQ3Kc8GhkVCKa4DzaD1HaLNXYUx3WVFs2a4igPueDA+RGDI65nTAwZDKV5DwBXfakGqzarWNTVZ2xvfhZEGwmQvOQuRlTWi1xWk7bkE1MepQrBkBTgtMEgUTsrE0QMiVzwbN/Bkqp/pPoPOeV0bDgbP6bufpU6jvs2rbMvA7P9fXbPzmZ984mar/X84CzvlVl+3n/dvf7t/mT68UXxggfrjdKCtPPKUMpTZUFKzbQPQoKVlhmZ4oF4yZNmQSWlQFownllyHgWgVkJlSnPjDSr/F+IZe1W8Y5F74gpcRE3ASOgQmUBiWqbsyAYO5BRpLskYn0y0AfPllOPomPxf4pkEeEv8GpsldZsVhr2r03JyVo4ys2kWIf/uZXfTK32WcdLEN17H98ODfMeK9oM9wJ43sdu9+wHUkQLJFgUAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 14:40:31 GMT"
+              "value": "Wed, 26 Oct 2022 13:28:02 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666622432"
+              "value": "1666790883"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,15 +117,15 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "29367"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666622432"
+              "value": "1666790883"
             },
             {
               "name": "etag",
-              "value": "W/\"4f2-cyyMsHYYaDHvf1Tr7sTRr5hx9y0\""
+              "value": "W/\"516-rSQx1piG8hCGvltSD0N1j92FJ3Q\""
             },
             {
               "name": "content-encoding",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f377d388368c09-EWR"
+              "value": "76038864cd8bc439-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T14:40:31.115Z",
-        "time": 456,
+        "startedDateTime": "2022-10-26T13:28:01.933Z",
+        "time": 476,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 456
+          "wait": 476
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getContractEventLogs-default_3767259827/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getContractEventLogs-default_3767259827/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "072ef266bd109dcf162ca3adf770e78c",
+        "_id": "5bb604cc895fdda4f0308a72b7e24440",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,24 +56,24 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"first\":2,\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
         },
         "response": {
-          "bodySize": 740,
+          "bodySize": 796,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 740,
-            "text": "[\"H4sIAAAAAAAAA8WR22obMRCG7/sYe52UkVbSSIZeBOPSlOKG1JBDKWGkGTkn74bdNSQEv3u1SQNpXNpcBAq6GGb0/3P47iumgarJfZXaZugoDWNMzJ30fTWp4NaBGEbvnPZZyBn0Gb0lxygIBhGTd4TJVTvVdbvsR/kNLWW/ye0Yn1M/l9vhoKSqydCtZaeShqfrrm+74n9y/Pnu5Pj6Mmq7Pj2aAx2F9dfL2YfidnY23N1IQ6sirA6eLDdFz0spfb7fV03LMjaJ1226mq9XUYqnsl55E8JONeqLdnG4N//2cXZYPHPXrvaeLZddiswcksqMlhAdhBqp1pAVE2RKSqyPoUiH9rmQ2XnU1qccXU0e0WDtRwupU1K1YFCAoMerSD9crGgQnrZNvuhWwnvlyJUGrXcV7GqzUGai3MSG9wBwOrbqqOkLiou2+UT9+SMGJ4aMD7XPgKiJXAlCsmBSmc9GZ8si4kLtODAQG5eITG08S4xRy8MGV9K8Eerf4MwOp6jV9Ml186vVPpdarYL68//FwzibF7XFuHuW7ku73KqV3KywL/m/oq/1q9BHjcFqcEbFaKHs6NlFUZoxgJRrC0Dxki30nsloUhglieYQFGoGkwsAF5OhqAOZoDO8Fj3of6CPqYyZvWbRCaNLVtAyezu+WqGxxlIOGAo8hmjriD4pMMqDEgjG/S/0aJR5c/Q/tguleyMPJ9uSvRxvs3n3E6glA7LyBAAA\"]"
+            "size": 796,
+            "text": "[\"H4sIAAAAAAAAA8WTW2sbMRBG3/sz9tkpo7tk6INxtzSlOMEx5FJKGEkjx7G9a3bXkBD836t1m5LGIaFQ6NMKifONZo72oYjYYTF8KEJddQ2Grl9jjA21bTEs4E4DyWis1twmQi2NTcYq1NGQAWmMCVajCboYFKt63vb4Bud0XKW6X99gO6G77jRvFcOu2dKgoCqOt01bNzn/8uLL/eXF6tZztb06nwCeu+3Jbfkhp11fd/cbqnCdweL0MXKX+TinXOfbQ1HVkfoiflWH5WS79pQzmbKCS+UGRc9ndjYdTc4+ldOcmZp6PXrSXICYmI2i/yapLKDTgSFPIHVwMQQ0iLnNjHb1U9ByxTMarecOlIkMEwnQ3Kc8GhkVCKa4DzaD1HaLNXYUx3WVFs2a4igPueDA+RGDI65nTAwZDKV5DwBXfakGqzarWNTVZ2xvfhZEGwmQvOQuRlTWi1xWk7bkE1MepQrBkBTgtMEgUTsrE0QMiVzwbN/Bkqp/pPoPOeV0bDgbP6bufpU6jvs2rbMvA7P9fXbPzmZ984mar/X84CzvlVl+3n/dvf7t/mT68UXxggfrjdKCtPPKUMpTZUFKzbQPQoKVlhmZ4oF4yZNmQSWlQFownllyHgWgVkJlSnPjDSr/F+IZe1W8Y5F74gpcRE3ASOgQmUBiWqbsyAYO5BRpLskYn0y0AfPllOPomPxf4pkEeEv8GpsldZsVhr2r03JyVo4ys2kWIf/uZXfTK32WcdLEN17H98ODfMeK9oM9wJ43sdu9+wHUkQLJFgUAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 14:40:33 GMT"
+              "value": "Wed, 26 Oct 2022 13:24:43 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666622433"
+              "value": "1666790684"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,15 +117,15 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "30322"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666622433"
+              "value": "1666790684"
             },
             {
               "name": "etag",
-              "value": "W/\"4f2-cyyMsHYYaDHvf1Tr7sTRr5hx9y0\""
+              "value": "W/\"516-rSQx1piG8hCGvltSD0N1j92FJ3Q\""
             },
             {
               "name": "content-encoding",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f377d97fdbc43b-EWR"
+              "value": "7603838afae68cb1-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T14:40:31.897Z",
-        "time": 1372,
+        "startedDateTime": "2022-10-26T13:24:43.265Z",
+        "time": 694,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1372
+          "wait": 694
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getContractEventLogs-iterate_2551668864/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getContractEventLogs-iterate_2551668864/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "bed538e64f7f4f7c23658a0bf9bfb31d",
+        "_id": "5ddcfb59373e1d1309f0c9661b20166d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,24 +56,24 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\",\"first\":2,\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"address\":\"0x2106c00ac7da0a3430ae667879139e832307aeaa\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
         },
         "response": {
-          "bodySize": 808,
+          "bodySize": 796,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 808,
-            "text": "[\"H4sIAAAAAAAAA8VSy2obQRC85zP2bId5PwQ5CEUhDkE2ssCPEEzPdI8sW9oVqxXYGP97ekUc/MLOIZDb0D1V1d1VdxVCB9XgrspN3bWQu/4NiC1tNtWgEjdKCpeFgOwRBGijBZBzPvgodaSglRYeCKDaq5bNfNPD1zCng7o0/fsSNhO66Y64VA26dkt7FdU42rabpmX+s9Nvt2eny6uk7Pb8ZCLgJG4Pr8afmO3iortdUw0rBlZHD5T3jMc5sc6Pu6pukHqRtGzy9WS7SsSc0gZhrBV7VY9n7OH083jKhKVtVsNHm2nBS+Sis3JgIeVYsi85KNIxofGIFoGSNQztmsdAiwZRZbA5QbSOZLLgHDKBVz5GF0rEIiEzkDbdYgUd4aipy6JdEQ75wpUSSu1Lsa/UTNqBigMbPwohznupFuoN+7Bo6q+wudwJkiOFzhabEbCgKiQzGdb0kZKPxvIw2bjonOABig+QUWgPKlhtTAm7Da6p/kc+P3FmPB15JUcPrPe/pQ6Qe9Yq/fr/2W4c/ryC9pq69RLyzqqj8eR4PGTMul1kdnzc8QUE3ybaZzyHLVL7vZn3JE8aXBtzQrj+RkB0kPpPQGbT4eT4y6sZ8exuBBuVkEqmjMEYlzPaaGVAgbFABidRvciINjGxEyapICz45JUQmGyR6AwIrckErbGkv8uIHgg5UPqtjCgJbI/UuSAFxfMBZaWzy5zqyD2QQnNoUiG0RieMbK0iAkccYZfV/8pICMa+k5EnvVm/e3nH+p8vG6xe0+5kL2DPx7u///AL+I9qaBgFAAA=\"]"
+            "size": 796,
+            "text": "[\"H4sIAAAAAAAAA8WSW0scQRCF3/Mz5lmluvo2PZAH2SzEEFYxgpcQpKare13dnVlmZsEg+99Ts0SImgQDQt6a7j6nLud7KJgGKqqHIrbN0FEcxjMxd6nvi6qAe1TgIgBFzwSkjQZKzvnSB6VDKjVq8JSIir1i2c77Ub6meTpqcjueb6ifpfvhRK6Kaug2aa9IDU82Xd924n958en75cXytka7uTqfAZ2HzfHt9L24XV8P39epoZUIi5NHy63oeZ6kzteHomk5jUXqZRvvZptVncRT2VIF62CvGPWiPT79MD0Vw9y1q8NfJtNQIiEzAJaolUFNNtfGg5GJyhABTS1/WKRD+0SYndHKZ0jssKxjstbbMmAOjkNki1lFDfW4ktQPixUNiSdtkxfdKvGhbLhAQNxXsI/mTPnKYmX8AQBcjaU6anrJYdE2H6m/2RWkVDu0tdcBTelLYAdoIdXeZamuSZMJJkJyhpxi7bQjNtKTRJc5BtxNcJeaN8r5STLT04lHNXl03f4sdcTy5qxWv/9/tmtHPq+ou0vDeklxF9XJdPZleiiadbeIkvh0kA3AAahnLscdp+5zOx8tnjzI3VT4kPs/4wHG2lfh4UPMOqIjS3UMOfocS0w61Gw8s2XJxZoXeFg2zBjJxpoExKRqS85JDtmjD8GVOXBWFF+BB54pW2GobPgbHsklZGezjUycGXNSMQkKzgdhJBgrzUTjghNsvHRRUmTQnrC02phc/i88rEX9NnhAsP8MyLeXD9Jmk3a7fSF7Psd2++4HQAq9KDwFAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 15:16:58 GMT"
+              "value": "Wed, 26 Oct 2022 13:24:44 GMT"
             },
             {
               "name": "content-type",
@@ -101,31 +101,31 @@
             },
             {
               "name": "x-ratelimit-rpslimit",
-              "value": "30"
+              "value": "4840"
             },
             {
               "name": "x-ratelimit-rpsremaining",
-              "value": "29"
+              "value": "4839"
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666624619"
+              "value": "1666790685"
             },
             {
               "name": "x-ratelimit-rpmlimit",
-              "value": "230"
+              "value": "60000"
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "229"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666624619"
+              "value": "1666790685"
             },
             {
               "name": "etag",
-              "value": "W/\"518-3fyhUqGJ7alIUMfvcKN2k20HZyY\""
+              "value": "W/\"53c-TU5w6HT8s0jG9BI+u0X0FBYXQFk\""
             },
             {
               "name": "content-encoding",
@@ -141,17 +141,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f3ad375caa1760-EWR"
+              "value": "7603838f5c2ce71c-EWR"
             }
           ],
-          "headersSize": 553,
+          "headersSize": 561,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T15:16:58.018Z",
-        "time": 368,
+        "startedDateTime": "2022-10-26T13:24:43.971Z",
+        "time": 198,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,11 +159,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 368
+          "wait": 198
         }
       },
       {
-        "_id": "c6cf15d652d5bf17b68ae101696e906c",
+        "_id": "937276e229ce808ed1a738099fbcea66",
         "_order": 0,
         "cache": {},
         "request": {
@@ -211,24 +211,24 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\",\"first\":2,\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"address\":\"0x2106c00ac7da0a3430ae667879139e832307aeaa\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
         },
         "response": {
-          "bodySize": 808,
+          "bodySize": 752,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 808,
-            "text": "[\"H4sIAAAAAAAAA8WTTWsbMRCG7/0Ze07C6Fsy9GBcl6a0TkgM+SgljKSR48TeNbtrSAn+7x2bpqRJSHoo9CZm5n1HM490X2XssRrcV6mp+xZTvz1jzi11XTWo4E4KsAkAk8sIqLQCJGudd0GoQF5JBQ4JsdqrFs2s28pXOKPDujTb8zV2E7rrjzlUDfp2TXsV1Xm0brumZf+L888/Ls4XN1Ga9eXZBPAsrI9uvr5nt6ur/seKalyysDp+sNywPs+I+3y7r+om07ZJXDTpdrJeRmJPYVzQYMxetdWzdnoynJx+HJ+wZ2mb5fDRcFQUFJRCeXTSGKm0EdZ76UIUQgobwYCh4FnaN4+FJWIsGqJIjmSB6BF1tqFIAgqmKBFLUESGhdT18yX2lEdNXebtkvKQl1xJkHJfwL4UU9ADCQPtDgDgctuqxbpjFPOm/oTd9a4huyvesycd0LgYciGbgo5ZGy98lrYUI0kbV7KSEXPhMohJe5WjSzbuJril+h+h/gPO+GTkpBg9uG5+tTrMnPPBi5frp7vrbJ7kptvZC7VfmtmzHMfGzJ7jr6AHMOo3+qOTDy9yT5YwiuiVttrFmJPwRcusFPKsJYrCO1BkXuCulXWUdY5ZcIHSnh8Kx7LyYDD5HCXkkOgvuMNU6IHxAyFe426TgVAIUpASPCYLMRdfKEkgfuWaxyURYvLGgcyWkspaCschSBCj/V/cnbVvYF9ie0v9aoFpR+p4PDkdD1mzaueJ//q45wXAAYgnLkdtfuN1fH+e4DvWtFvsM9nTITabdz8BVsUK7BUFAAA=\"]"
+            "size": 752,
+            "text": "[\"H4sIAAAAAAAAA8WS20ocQRCG7/MYc62huvq8kAtZDDEkRsyChxCkurt6Pe2MzMyCIvvuqTUKxk1CLoTcNVX9/3X46r4pNFIzuW9y14495XH9plJ6HoZm0sAtKnAZgLIvBKSNBmLnfPBR6chBowZPTNRsNdfdfFjLb2jOe23t1u9zGvb5djyQUDMZ+yVvNdyW6bIful78T44/3p0cX18mtMvTo32go7j8cvn5nbidnY13N9zSQoTNwZPlSvRlzlLn233TdoXXRdJ1l6/2l4vE4qlsAB2U3mrWetHODnf2v77fPRTP2neLnWfDeccqko0IClXKJRjjci42WhUKlFgpk1MFRTp2z4XaxBSrNwkDWPLJI0BJtqriDIHWbILWpSYR8jBeLGjkMu3aetEvuOzIkhsExG0F24gzpSegJqjfAsDpulRP7SAoLrr2Aw3njxhItqx0roUDSn/EGXV2uWYhQUQKdGaTKhdrdCpRCCEzOY7WufxzgituXwn1L3B2D6ce1fTJdfVYaq9ILgRjf/9/9tDO6kVutp69cv+pm2/kJLYr7CX+R/Q+GrD2X9Bz1VAJlQ7k0VrUxioXAvqYlByDS2DBcgwb6GuiVA0klT1jhRSITHGxIoPsumqVatTM9h/QqxmYCcLE+L+hF3ctew9s5FR9iqWyy9GkYmyQM0VXq0U21teiMVGp8g1SlgssyWeX/hv6GNSro/++mZDqLT+sbEP2sr3V6s0Pl5tVcvIEAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 15:19:19 GMT"
+              "value": "Wed, 26 Oct 2022 13:24:44 GMT"
             },
             {
               "name": "content-type",
@@ -264,7 +264,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666624760"
+              "value": "1666790685"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666624760"
+              "value": "1666790685"
             },
             {
               "name": "etag",
-              "value": "W/\"515-k/TgNw4pF9SoDWzRLB1tX9/yW6g\""
+              "value": "W/\"4f2-0FHr4bME0R66QLyk82YpvvyErek\""
             },
             {
               "name": "content-encoding",
@@ -296,7 +296,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f3b0abfa7e32e2-EWR"
+              "value": "76038390be121921-EWR"
             }
           ],
           "headersSize": 561,
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T15:19:19.572Z",
-        "time": 370,
+        "startedDateTime": "2022-10-26T13:24:44.181Z",
+        "time": 175,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 370
+          "wait": 175
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getContractEventLogs-null_1241719855/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getContractEventLogs-null_1241719855/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "a2fa01bdf7e649b891e022dd38871593",
+        "_id": "d6037e3cc29f877c9aaa8ac585b1e646",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"first\":2,\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 14:46:24 GMT"
+              "value": "Wed, 26 Oct 2022 13:24:44 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666622785"
+              "value": "1666790685"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "1379"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666622785"
+              "value": "1666790685"
             },
             {
               "name": "etag",
@@ -141,17 +141,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f3806fefea9dff-EWR"
+              "value": "76038392093de6e0-EWR"
             }
           ],
-          "headersSize": 559,
+          "headersSize": 560,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T14:46:23.726Z",
-        "time": 242,
+        "startedDateTime": "2022-10-26T13:24:44.387Z",
+        "time": 105,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 105
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getContractEventLogs-onetype_3085403286/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getContractEventLogs-onetype_3085403286/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "b74d3a073fad727706bbd53c86bf86d4",
+        "_id": "0639bf4c9ee78d3efbc064bd5aa8d5f2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"first\":2,\"filter\":{\"typeIn\":[\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractEvents\",\"variables\":{\"first\":2,\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"MINT\"]}},\"query\":\"query ContractEvents($address: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    logs(filter: $filter, first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          blockNumber\\n          type\\n          fromAddress\\n          toAddress\\n          estimatedConfirmedAt\\n          transactionHash\\n          token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            ... on ERC721Token {\\n              tokenId\\n              __typename\\n            }\\n            __typename\\n          }\\n          ... on OrderLog {\\n            marketplace\\n            priceInEth\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 24 Oct 2022 14:40:31 GMT"
+              "value": "Wed, 26 Oct 2022 13:24:43 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666622432"
+              "value": "1666790684"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "29831"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666622432"
+              "value": "1666790684"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75f377d66e5b9e08-EWR"
+              "value": "76038388aec98c9c-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-24T14:40:31.595Z",
-        "time": 291,
+        "startedDateTime": "2022-10-26T13:24:42.894Z",
+        "time": 357,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 291
+          "wait": 357
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getEventLogs-alltypes_2299671212/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getEventLogs-alltypes_2299671212/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3116c5519928dff004d954a47dbe47db",
+        "_id": "ed1f6168e520c902b597563eaa213c26",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"tokenId\":\"100\",\"first\":2,\"filter\":{\"typeIn\":[\"MINT\",\"ORDER\",\"TRANSFER\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"tokenId\":\"100\",\"first\":2,\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"MINT\",\"ORDER\",\"TRANSFER\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 21:05:15 GMT"
+              "value": "Wed, 26 Oct 2022 13:34:44 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666213516"
+              "value": "1666791285"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666213516"
+              "value": "1666791285"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75cc787e78348c09-EWR"
+              "value": "76039237ea7f78d6-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T21:05:13.932Z",
-        "time": 1301,
+        "startedDateTime": "2022-10-26T13:34:44.345Z",
+        "time": 151,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1301
+          "wait": 151
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getEventLogs-iterate_2402465430/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getEventLogs-iterate_2402465430/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "bb29ec52d1fe69b2ef759838c5aea3a8",
+        "_id": "73db0ae75384657ee726e71c2588cac5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"first\":2,\"tokenId\":\"100\",\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"first\":2,\"tokenId\":\"100\",\"after\":\"YXJyYXljb25uZWN0aW9uOjE=\",\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 21:10:42 GMT"
+              "value": "Wed, 26 Oct 2022 13:34:44 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666213843"
+              "value": "1666791285"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "40177"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666213843"
+              "value": "1666791285"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75cc80807fbb8c42-EWR"
+              "value": "7603923a8db6184d-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T21:10:41.911Z",
-        "time": 112,
+        "startedDateTime": "2022-10-26T13:34:44.794Z",
+        "time": 118,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 112
+          "wait": 118
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getEventLogs-notypes_2921590472/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getEventLogs-notypes_2921590472/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "8623d54ace3be1835c491cf0ba118145",
+        "_id": "bea08230082b9353b9e232af317f754e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"first\":2,\"tokenId\":\"100\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"first\":2,\"tokenId\":\"100\",\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 21:05:16 GMT"
+              "value": "Wed, 26 Oct 2022 13:34:44 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666213517"
+              "value": "1666791285"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666213517"
+              "value": "1666791285"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75cc78881ca21a38-EWR"
+              "value": "76039239bc82c459-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T21:05:15.476Z",
-        "time": 710,
+        "startedDateTime": "2022-10-26T13:34:44.658Z",
+        "time": 128,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 710
+          "wait": 128
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getEventLogs-null_3627347361/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getEventLogs-null_3627347361/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "ab35c8b19144408632359fde8e328abe",
+        "_id": "edba6b4c149eb8a999a7782d1535055d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"first\":2,\"tokenId\":\"100\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"first\":2,\"tokenId\":\"100\",\"address\":\"0x11111111111110thisisnotanaddress01111111\",\"filter\":{\"typeIn\":[\"TRANSFER\",\"ORDER\",\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 21:05:16 GMT"
+              "value": "Wed, 26 Oct 2022 13:34:45 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666213517"
+              "value": "1666791286"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666213517"
+              "value": "1666791286"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75cc788d6a8e3344-EWR"
+              "value": "7603923b5e9117e1-EWR"
             }
           ],
           "headersSize": 560,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T21:05:16.327Z",
-        "time": 144,
+        "startedDateTime": "2022-10-26T13:34:44.924Z",
+        "time": 126,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 144
+          "wait": 126
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getEventLogs-onetype_1324985312/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getEventLogs-onetype_1324985312/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "2c45307b08b1ffce6df3c6ded4d8b2da",
+        "_id": "a2e17d43a02fc063d55e457480fcc43c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"address\":\"0x60E4d786628Fea6478F785A6d7e704777c86a7c6\",\"tokenId\":\"100\",\"filter\":{\"typeIn\":[\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"NFTEvents\",\"variables\":{\"tokenId\":\"100\",\"address\":\"0x60e4d786628fea6478f785a6d7e704777c86a7c6\",\"filter\":{\"typeIn\":[\"MINT\"]}},\"query\":\"query NFTEvents($address: String!, $tokenId: String!, $filter: LogsFilterInputType, $first: Int, $after: String) {\\n  token(contractAddress: $address, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      contract {\\n        address\\n        __typename\\n      }\\n      logs(filter: $filter, first: $first, after: $after) {\\n        edges {\\n          node {\\n            blockNumber\\n            type\\n            fromAddress\\n            toAddress\\n            estimatedConfirmedAt\\n            transactionHash\\n            ... on OrderLog {\\n              marketplace\\n              priceInEth\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        pageInfo {\\n          hasNextPage\\n          endCursor\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 19 Oct 2022 21:10:41 GMT"
+              "value": "Wed, 26 Oct 2022 13:34:44 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666213842"
+              "value": "1666791285"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -117,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "40040"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666213842"
+              "value": "1666791285"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75cc807f6d261815-EWR"
+              "value": "76039238c99032dc-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-19T21:10:41.729Z",
-        "time": 153,
+        "startedDateTime": "2022-10-26T13:34:44.516Z",
+        "time": 132,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 153
+          "wait": 132
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getNFTDetails-full_3351509418/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getNFTDetails-full_3351509418/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4e0fd7fefa1be640f4dc118d0dd47913",
+        "_id": "ffb2b720ed28ec61e1f4c53ad6092f75",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"Token\",\"variables\":{\"contractAddress\":\"0x23581767a106ae21c074b2276D25e5C3e136a68b\",\"tokenId\":\"400\"},\"query\":\"query Token($contractAddress: String!, $tokenId: String!) {\\n  token(contractAddress: $contractAddress, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      attributes {\\n        name\\n        value\\n        __typename\\n      }\\n      contract {\\n        address\\n        isVerified\\n        tokenStandard\\n        ... on ERC721Contract {\\n          name\\n          __typename\\n        }\\n        __typename\\n      }\\n      images {\\n        height\\n        mimeType\\n        url\\n        width\\n        __typename\\n      }\\n      name\\n      symbol\\n      metadata {\\n        animation_url\\n        background_color\\n        description\\n        external_url\\n        image\\n        image_data\\n        name\\n        youtube_url\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"Token\",\"variables\":{\"contractAddress\":\"0x23581767a106ae21c074b2276d25e5c3e136a68b\",\"tokenId\":\"400\"},\"query\":\"query Token($contractAddress: String!, $tokenId: String!) {\\n  token(contractAddress: $contractAddress, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      attributes {\\n        name\\n        value\\n        __typename\\n      }\\n      contract {\\n        address\\n        isVerified\\n        tokenStandard\\n        ... on ERC721Contract {\\n          name\\n          __typename\\n        }\\n        __typename\\n      }\\n      images {\\n        height\\n        mimeType\\n        url\\n        width\\n        __typename\\n      }\\n      name\\n      symbol\\n      metadata {\\n        animation_url\\n        background_color\\n        description\\n        external_url\\n        image\\n        image_data\\n        name\\n        youtube_url\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 21 Oct 2022 14:36:32 GMT"
+              "value": "Wed, 26 Oct 2022 13:33:45 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666362993"
+              "value": "1666791226"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666362993"
+              "value": "1666791226"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75dab9de6f03190e-EWR"
+              "value": "760390c86a02181d-EWR"
             }
           ],
           "headersSize": 561,
@@ -150,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-21T14:36:32.286Z",
-        "time": 156,
+        "startedDateTime": "2022-10-26T13:33:45.566Z",
+        "time": 255,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -159,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 156
+          "wait": 255
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getNFTDetails-null_3423448546/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getNFTDetails-null_3423448546/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "1d5ad32ec5227861632152246f566373",
+        "_id": "4bb2e0fb7a6ecdb0fafacf6b6b5cc4a6",
         "_order": 0,
         "cache": {},
         "request": {
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"Token\",\"variables\":{\"contractAddress\":\"0x23581767a106ae21c074b2276D25e5C3e136a68b\",\"tokenId\":\"444444444\"},\"query\":\"query Token($contractAddress: String!, $tokenId: String!) {\\n  token(contractAddress: $contractAddress, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      attributes {\\n        name\\n        value\\n        __typename\\n      }\\n      contract {\\n        address\\n        isVerified\\n        tokenStandard\\n        ... on ERC721Contract {\\n          name\\n          __typename\\n        }\\n        __typename\\n      }\\n      images {\\n        height\\n        mimeType\\n        url\\n        width\\n        __typename\\n      }\\n      name\\n      symbol\\n      metadata {\\n        animation_url\\n        background_color\\n        description\\n        external_url\\n        image\\n        image_data\\n        name\\n        youtube_url\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"Token\",\"variables\":{\"contractAddress\":\"0x23581767a106ae21c074b2276d25e5c3e136a68b\",\"tokenId\":\"444444444\"},\"query\":\"query Token($contractAddress: String!, $tokenId: String!) {\\n  token(contractAddress: $contractAddress, tokenId: $tokenId) {\\n    ... on ERC721Token {\\n      tokenId\\n      attributes {\\n        name\\n        value\\n        __typename\\n      }\\n      contract {\\n        address\\n        isVerified\\n        tokenStandard\\n        ... on ERC721Contract {\\n          name\\n          __typename\\n        }\\n        __typename\\n      }\\n      images {\\n        height\\n        mimeType\\n        url\\n        width\\n        __typename\\n      }\\n      name\\n      symbol\\n      metadata {\\n        animation_url\\n        background_color\\n        description\\n        external_url\\n        image\\n        image_data\\n        name\\n        youtube_url\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -73,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 21 Oct 2022 14:36:32 GMT"
+              "value": "Wed, 26 Oct 2022 13:33:46 GMT"
             },
             {
               "name": "content-type",
@@ -109,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1666362993"
+              "value": "1666791226"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -121,7 +121,7 @@
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1666362993"
+              "value": "1666791226"
             },
             {
               "name": "etag",
@@ -141,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75dab9dfa8f2c413-EWR"
+              "value": "760390ca08f232e4-EWR"
             }
           ],
           "headersSize": 560,
@@ -150,7 +150,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-21T14:36:32.460Z",
+        "startedDateTime": "2022-10-26T13:33:45.837Z",
         "time": 152,
         "timings": {
           "blocked": -1,

--- a/packages/libs/api/sdk/recordings/query-getNFTsByContractAddress-base_2505259894/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getNFTsByContractAddress-base_2505259894/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4975690aecc84912ab9435c30bb92019",
+        "_id": "d536ffb213d32e5bc92b4ce043cb269d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -24,11 +24,6 @@
               "_fromType": "array",
               "name": "content-type",
               "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-api-key",
-              "value": "cd100fedca484ece9deb2c17eb121aea"
             },
             {
               "_fromType": "array",
@@ -55,13 +50,13 @@
               "value": "graphql.icy.tools"
             }
           ],
-          "headersSize": 305,
+          "headersSize": 260,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractNFTs\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\",\"first\":5},\"query\":\"query ContractNFTs($address: String!, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    isVerified\\n    tokenStandard\\n    tokens(first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    ... on ERC721Contract {\\n      circulatingSupply\\n      name\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractNFTs\",\"variables\":{\"address\":\"0x2106c00ac7da0a3430ae667879139e832307aeaa\",\"first\":5},\"query\":\"query ContractNFTs($address: String!, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    isVerified\\n    tokenStandard\\n    tokens(first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    ... on ERC721Contract {\\n      circulatingSupply\\n      name\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -78,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 14 Oct 2022 13:12:27 GMT"
+              "value": "Wed, 26 Oct 2022 13:36:03 GMT"
             },
             {
               "name": "content-type",
@@ -106,27 +101,27 @@
             },
             {
               "name": "x-ratelimit-rpslimit",
-              "value": "5"
+              "value": "4840"
             },
             {
               "name": "x-ratelimit-rpsremaining",
-              "value": "4"
+              "value": "4839"
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1665753148"
+              "value": "1666791364"
             },
             {
               "name": "x-ratelimit-rpmlimit",
-              "value": "50"
+              "value": "60000"
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "49"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1665753148"
+              "value": "1666791364"
             },
             {
               "name": "etag",
@@ -146,17 +141,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "75a091107ce71a3c-EWR"
+              "value": "76039424ace6f060-EWR"
             }
           ],
-          "headersSize": 550,
+          "headersSize": 562,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-14T13:12:26.827Z",
-        "time": 236,
+        "startedDateTime": "2022-10-26T13:36:03.197Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 236
+          "wait": 181
         }
       }
     ],

--- a/packages/libs/api/sdk/recordings/query-getNFTsByContractAddress-iterates_392244344/recording.har
+++ b/packages/libs/api/sdk/recordings/query-getNFTsByContractAddress-iterates_392244344/recording.har
@@ -8,162 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4975690aecc84912ab9435c30bb92019",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 899,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "899"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "graphql.icy.tools"
-            }
-          ],
-          "headersSize": 260,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"operationName\":\"ContractNFTs\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\",\"first\":5},\"query\":\"query ContractNFTs($address: String!, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    isVerified\\n    tokenStandard\\n    tokens(first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    ... on ERC721Contract {\\n      circulatingSupply\\n      name\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
-          },
-          "queryString": [],
-          "url": "https://graphql.icy.tools/graphql"
-        },
-        "response": {
-          "bodySize": 744,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json; charset=utf-8",
-            "size": 744,
-            "text": "[\"H4sIAAAAAAAAA9WUXW+bMBSG7/crJl9HwWDAgNSrtBedprRb2/VjqirHNiktsZFttqAo/30mHxdbq2yTURK4snw4x48tPe8CMGIIyBaASmEUoaZdE8YU1xpkAM4DH8YUQkIxI5CgEEHC4xgnOPVRyhMUIIgJJwQMQKG/cVXkBWcgy0mp+QAY+crFlSGCEWV3wdnXEQ58sCno9rCKTPm5yGW7fiZ6zOfm0m6BzKjaTuCCjWqlpbLd93efmvu78mUSRPXD7RiS27S+ePlyYuc9PZmm4oLMbCO43I5c2n425fac7wsgJOPtIaujz1sa2ELPyPaHWpV289mYSmeety4MC9oYKUs9/CnVK1d6yPgPb649KsuSU1NIob1/fyVvfW+PMp7yEPIITpDvxyzFuR9hEmIc5CGGkz9vdL1ibonsnf6HVM/6QjpjfSEtp30hnZcHJH0cdBEqv41fx8doO3X5bnnF8Ka22j1jmyd8mwX+wbIA8jRMKJskQZJjiOOYRpGP/ChNCMoTxI4nC/ZG6pwFeyN1zoK9kTpngQtpv7IgOFgWBMcje3cozjZ3h+Ksa3cozj7uROmXcOhgwqHjEa47FGfhukNxFq47FGfhdqL0S7jwYMKFxyNcdyjOwnWH4ixcdyjOwu1EOVrhHt8r2aFi/RBtKy0UrUtiCjG9qquqbECW2m8ANi2fpayaj6dS1EZbSN3MJrJ99dOL8c3136iXyw+/AA/57CjXEwAA\"]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 14 Oct 2022 14:40:52 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-powered-by",
-              "value": "Express"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "x-ratelimit-rpslimit",
-              "value": "4840"
-            },
-            {
-              "name": "x-ratelimit-rpsremaining",
-              "value": "4839"
-            },
-            {
-              "name": "x-ratelimit-rpsreset",
-              "value": "1665758452"
-            },
-            {
-              "name": "x-ratelimit-rpmlimit",
-              "value": "60000"
-            },
-            {
-              "name": "x-ratelimit-rpmremaining",
-              "value": "50001"
-            },
-            {
-              "name": "x-ratelimit-rpmreset",
-              "value": "1665758452"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"13d7-PkE3g6d2iFb2Ax3Y69MlJtl8isk\""
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "75a11294af361962-EWR"
-            }
-          ],
-          "headersSize": 562,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2022-10-14T14:40:51.865Z",
-        "time": 151,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 151
-        }
-      },
-      {
-        "_id": "be6e2d00815d9d3a63870d076a9edcd2",
+        "_id": "2a09814ecdefacb0583d2c6e1e10131f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -211,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"ContractNFTs\",\"variables\":{\"address\":\"0x2106C00Ac7dA0A3430aE667879139E832307AeAa\",\"first\":5,\"after\":\"YXJyYXljb25uZWN0aW9uOjQ=\"},\"query\":\"query ContractNFTs($address: String!, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    isVerified\\n    tokenStandard\\n    tokens(first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    ... on ERC721Contract {\\n      circulatingSupply\\n      name\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
+            "text": "{\"operationName\":\"ContractNFTs\",\"variables\":{\"address\":\"0x2106c00ac7da0a3430ae667879139e832307aeaa\",\"first\":5,\"after\":\"YXJyYXljb25uZWN0aW9uOjQ=\"},\"query\":\"query ContractNFTs($address: String!, $first: Int, $after: String) {\\n  contract(address: $address) {\\n    address\\n    isVerified\\n    tokenStandard\\n    tokens(first: $first, after: $after) {\\n      pageInfo {\\n        hasNextPage\\n        endCursor\\n        __typename\\n      }\\n      edges {\\n        node {\\n          tokenId\\n          images {\\n            url\\n            __typename\\n          }\\n          ... on ERC721Token {\\n            contract {\\n              address\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    ... on ERC721Contract {\\n      circulatingSupply\\n      name\\n      symbol\\n      __typename\\n    }\\n    __typename\\n  }\\n}\"}"
           },
           "queryString": [],
           "url": "https://graphql.icy.tools/graphql"
@@ -228,7 +73,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 14 Oct 2022 14:40:52 GMT"
+              "value": "Wed, 26 Oct 2022 13:36:03 GMT"
             },
             {
               "name": "content-type",
@@ -264,7 +109,7 @@
             },
             {
               "name": "x-ratelimit-rpsreset",
-              "value": "1665758453"
+              "value": "1666791364"
             },
             {
               "name": "x-ratelimit-rpmlimit",
@@ -272,11 +117,11 @@
             },
             {
               "name": "x-ratelimit-rpmremaining",
-              "value": "50137"
+              "value": "59999"
             },
             {
               "name": "x-ratelimit-rpmreset",
-              "value": "1665758453"
+              "value": "1666791364"
             },
             {
               "name": "etag",
@@ -296,7 +141,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "75a11295984e9e1a-EWR"
+              "value": "76039425c9728c78-EWR"
             }
           ],
           "headersSize": 562,
@@ -305,8 +150,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-10-14T14:40:52.027Z",
-        "time": 216,
+        "startedDateTime": "2022-10-26T13:36:03.397Z",
+        "time": 157,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 216
+          "wait": 157
         }
       }
     ],

--- a/packages/libs/api/sdk/src/queries/nft/getCollectionDetails/getCollectionDetails.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getCollectionDetails/getCollectionDetails.spec.ts
@@ -6,7 +6,9 @@ const client = new QuickNodeSDK();
 describe('getCollectionDetails', () => {
   it('executes correctly', async () => {
     await withPolly(
-      { recordingName: 'query-getCollectionDetails-base' },
+      {
+        recordingName: 'query-getCollectionDetails-base',
+      },
       async () => {
         const { data } = await client.nft.getCollectionDetails({
           address: '0x2106C00Ac7dA0A3430aE667879139E832307AeAa',
@@ -42,16 +44,10 @@ describe('getCollectionDetails', () => {
                 valueCount: 20,
               },
               {
-                name: 'Mouth',
-                rarity: 0.77007700770077,
-                value: 'Kinky',
-                valueCount: 77,
-              },
-              {
                 name: 'Back-accessory',
-                rarity: 1.5001500150015001,
+                rarity: 1.51015101510151,
                 value: 'King',
-                valueCount: 150,
+                valueCount: 151,
               },
               {
                 name: 'Headgear',
@@ -70,12 +66,6 @@ describe('getCollectionDetails', () => {
                 rarity: 1.3201320132013201,
                 value: 'Sleeping',
                 valueCount: 132,
-              },
-              {
-                name: 'Eyes',
-                rarity: 2.24022402240224,
-                value: 'Purple Party Glasses',
-                valueCount: 224,
               },
               {
                 name: 'Accessory',
@@ -120,6 +110,24 @@ describe('getCollectionDetails', () => {
                 valueCount: 190,
               },
               {
+                name: 'Accessory',
+                rarity: 0.53005300530053,
+                value: 'Diaper',
+                valueCount: 53,
+              },
+              {
+                name: 'Eyes',
+                rarity: 2.1702170217021703,
+                value: 'Surprised',
+                valueCount: 217,
+              },
+              {
+                name: 'Glaze',
+                rarity: 2.4002400240024,
+                value: 'Purple Candy',
+                valueCount: 240,
+              },
+              {
                 name: 'Headgear',
                 rarity: 1.5801580158015802,
                 value: 'Cat',
@@ -142,12 +150,6 @@ describe('getCollectionDetails', () => {
                 rarity: 1.7301730173017302,
                 value: 'Donut Inflatable',
                 valueCount: 173,
-              },
-              {
-                name: 'Glaze',
-                rarity: 3.26032603260326,
-                value: 'Galaxy',
-                valueCount: 326,
               },
               {
                 name: 'Headgear',
@@ -180,22 +182,10 @@ describe('getCollectionDetails', () => {
                 valueCount: 20,
               },
               {
-                name: 'Headgear',
-                rarity: 1.33013301330133,
-                value: 'Goose',
-                valueCount: 133,
-              },
-              {
                 name: 'Accessory',
                 rarity: 0.71007100710071,
                 value: 'Chastity Belt',
                 valueCount: 71,
-              },
-              {
-                name: 'Accessory',
-                rarity: 0.5200520052005201,
-                value: 'Diaper',
-                valueCount: 52,
               },
               {
                 name: 'Accessory',
@@ -211,39 +201,21 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Accessory',
-                rarity: 0.28002800280028,
-                value: 'Red Skirt',
-                valueCount: 28,
-              },
-              {
-                name: 'Accessory',
                 rarity: 0.15001500150015,
                 value: 'Green Pouch',
                 valueCount: 15,
               },
               {
                 name: 'Eyes',
-                rarity: 2.15021502150215,
-                value: 'Surprised',
-                valueCount: 215,
-              },
-              {
-                name: 'Eyes',
-                rarity: 2.6802680268026804,
-                value: 'Sunglasses',
-                valueCount: 268,
+                rarity: 2.25022502250225,
+                value: 'Purple Party Glasses',
+                valueCount: 225,
               },
               {
                 name: 'Headgear',
-                rarity: 1.24012401240124,
-                value: 'Pink Hat',
-                valueCount: 124,
-              },
-              {
-                name: 'Headgear',
-                rarity: 0.5800580058005801,
+                rarity: 0.59005900590059,
                 value: 'Donut Nest',
-                valueCount: 58,
+                valueCount: 59,
               },
               {
                 name: 'Headgear',
@@ -360,6 +332,24 @@ describe('getCollectionDetails', () => {
                 valueCount: 22,
               },
               {
+                name: 'Accessory',
+                rarity: 0.29002900290029004,
+                value: 'Red Skirt',
+                valueCount: 29,
+              },
+              {
+                name: 'Glaze',
+                rarity: 3.2703270327032703,
+                value: 'Galaxy',
+                valueCount: 327,
+              },
+              {
+                name: 'Headgear',
+                rarity: 1.3401340134013402,
+                value: 'Goose',
+                valueCount: 134,
+              },
+              {
                 name: 'Headgear',
                 rarity: 1.12011201120112,
                 value: 'Red Frog',
@@ -424,12 +414,6 @@ describe('getCollectionDetails', () => {
                 rarity: 3.6603660366036603,
                 value: 'Pink Candy',
                 valueCount: 366,
-              },
-              {
-                name: 'Glaze',
-                rarity: 1.0701070107010702,
-                value: 'Elegant Fuchsia',
-                valueCount: 107,
               },
               {
                 name: 'Headgear',
@@ -511,15 +495,15 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Background',
-                rarity: 4.130413041304131,
+                rarity: 4.14041404140414,
                 value: 'Green',
-                valueCount: 413,
+                valueCount: 414,
               },
               {
                 name: 'Eyes',
-                rarity: 3.53035303530353,
+                rarity: 3.5403540354035403,
                 value: 'Cool',
-                valueCount: 353,
+                valueCount: 354,
               },
               {
                 name: 'Glaze',
@@ -541,9 +525,9 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Background',
-                rarity: 4.490449044904491,
+                rarity: 4.5004500450045,
                 value: 'Jade',
-                valueCount: 449,
+                valueCount: 450,
               },
               {
                 name: 'Headgear',
@@ -553,9 +537,9 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Background',
-                rarity: 4.06040604060406,
+                rarity: 4.070407040704071,
                 value: 'Pink',
-                valueCount: 406,
+                valueCount: 407,
               },
               {
                 name: 'Headgear',
@@ -589,51 +573,57 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Mouth',
-                rarity: 0.9400940094009401,
+                rarity: 0.95009500950095,
                 value: 'Rainbow Beam',
-                valueCount: 94,
+                valueCount: 95,
               },
               {
                 name: 'Back-accessory',
-                rarity: 1.5901590159015901,
+                rarity: 1.6001600160016,
                 value: 'Superman',
-                valueCount: 159,
+                valueCount: 160,
               },
               {
                 name: 'Background',
-                rarity: 4.21042104210421,
+                rarity: 4.220422042204221,
                 value: 'Blue',
-                valueCount: 421,
+                valueCount: 422,
+              },
+              {
+                name: 'Eyes',
+                rarity: 2.69026902690269,
+                value: 'Sunglasses',
+                valueCount: 269,
+              },
+              {
+                name: 'Glaze',
+                rarity: 1.08010801080108,
+                value: 'Elegant Fuchsia',
+                valueCount: 108,
               },
               {
                 name: 'Headgear',
-                rarity: 0.7200720072007201,
+                rarity: 0.74007400740074,
                 value: 'Crown',
-                valueCount: 72,
+                valueCount: 74,
+              },
+              {
+                name: 'Mouth',
+                rarity: 0.7800780078007801,
+                value: 'Kinky',
+                valueCount: 78,
               },
               {
                 name: 'Background',
-                rarity: 4.48044804480448,
+                rarity: 4.490449044904491,
                 value: 'Purple',
-                valueCount: 448,
-              },
-              {
-                name: 'Base',
-                rarity: 29.732973297329732,
-                value: 'Donut Body',
-                valueCount: 2973,
+                valueCount: 449,
               },
               {
                 name: 'Eyes',
                 rarity: 1.39013901390139,
                 value: 'Green Party Glasses',
                 valueCount: 139,
-              },
-              {
-                name: 'Glaze',
-                rarity: 2.39023902390239,
-                value: 'Purple Candy',
-                valueCount: 239,
               },
               {
                 name: 'Headgear',
@@ -661,21 +651,15 @@ describe('getCollectionDetails', () => {
               },
               {
                 name: 'Accessory',
-                rarity: 1.7301730173017302,
+                rarity: 1.7401740174017402,
                 value: 'Babypink Pouch',
-                valueCount: 173,
+                valueCount: 174,
               },
               {
                 name: 'Glaze',
-                rarity: 0.89008900890089,
-                value: 'Rainbow',
-                valueCount: 89,
-              },
-              {
-                name: 'Glaze',
-                rarity: 3.77037703770377,
+                rarity: 3.7803780378037803,
                 value: 'Starcandy',
-                valueCount: 377,
+                valueCount: 378,
               },
               {
                 name: 'Headgear',
@@ -708,52 +692,70 @@ describe('getCollectionDetails', () => {
                 valueCount: 374,
               },
               {
-                name: 'Headgear',
-                rarity: 70.20702070207021,
-                value: null,
-                valueCount: 7020,
-              },
-              {
-                name: 'Eyes',
-                rarity: 70.20702070207021,
-                value: null,
-                valueCount: 7020,
-              },
-              {
-                name: 'Accessory',
-                rarity: 82.88828882888289,
-                value: null,
-                valueCount: 8288,
-              },
-              {
-                name: 'Mouth',
-                rarity: 87.31873187318732,
-                value: null,
-                valueCount: 8731,
-              },
-              {
-                name: 'Back-accessory',
-                rarity: 96.90969096909691,
-                value: null,
-                valueCount: 9690,
-              },
-              {
                 name: 'Base',
-                rarity: 70.22702270227023,
-                value: null,
-                valueCount: 7022,
+                rarity: 29.782978297829782,
+                value: 'Donut Body',
+                valueCount: 2978,
               },
               {
                 name: 'Glaze',
-                rarity: 70.21702170217021,
-                value: null,
-                valueCount: 7021,
+                rarity: 0.9000900090009001,
+                value: 'Rainbow',
+                valueCount: 90,
               },
               {
-                name: 'Background',
+                name: 'Headgear',
+                rarity: 1.2501250125012502,
+                value: 'Pink Hat',
+                valueCount: 125,
+              },
+              {
+                name: 'Headgear',
+                rarity: 70.15701570157016,
+                value: null,
+                valueCount: 7015,
+              },
+              {
+                name: 'Eyes',
+                rarity: 70.15701570157016,
+                value: null,
+                valueCount: 7015,
+              },
+              {
+                name: 'Accessory',
+                rarity: 82.85828582858286,
+                value: null,
+                valueCount: 8285,
+              },
+              {
+                name: 'Back-accessory',
+                rarity: 96.88968896889689,
+                value: null,
+                valueCount: 9688,
+              },
+              {
+                name: 'Base',
+                rarity: 70.17701770177018,
+                value: null,
+                valueCount: 7017,
+              },
+              {
+                name: 'Glaze',
                 rarity: 70.16701670167016,
                 value: null,
                 valueCount: 7016,
+              },
+              {
+                name: 'Mouth',
+                rarity: 87.2987298729873,
+                value: null,
+                valueCount: 8729,
+              },
+              {
+                name: 'Background',
+                rarity: 70.11701170117011,
+                value: null,
+                valueCount: 7011,
               },
             ],
             circulatingSupply: 9999,
@@ -774,7 +776,9 @@ describe('getCollectionDetails', () => {
 
   it('handles empty response', async () => {
     await withPolly(
-      { recordingName: 'query-getCollectionDetails-empty' },
+      {
+        recordingName: 'query-getCollectionDetails-empty',
+      },
       async () => {
         const { data } = await client.nft.getCollectionDetails({
           address: '0x11111111111110thisisnotanaddress01111111',

--- a/packages/libs/api/sdk/src/queries/nft/getContractEventLogs/getContractEventLogs.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getContractEventLogs/getContractEventLogs.spec.ts
@@ -6,9 +6,7 @@ const client = new QuickNodeSDK();
 describe('getContractEventLogs', () => {
   it('executes correctly with all types', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getContractEventLogs-alltypes',
-      },
+      { recordingName: 'query-getContractEventLogs-alltypes' },
       async () => {
         const { data } = await client.nft.getContractEventLogs({
           address: '0x60E4d786628Fea6478F785A6d7e704777c86a7c6',
@@ -25,34 +23,36 @@ describe('getContractEventLogs', () => {
             },
             logs: [
               {
-                blockNumber: 15818499,
+                blockNumber: 15832459,
                 type: 'TRANSFER',
-                fromAddress: '0xf6cbddd9c1fd75a7760937a320f1da0fac1e58b9',
-                toAddress: '0xdd687258cfb63a8774738d75ae3cc13e79107026',
-                estimatedConfirmedAt: '2022-10-24T14:16:59.000Z',
+                fromAddress: '0xc0df18d3c0dff4580a96c1a2f046c9dcca7aa704',
+                toAddress: '0x8252df1d8b29057d1afe3062bf5a64d503152bc8',
+                estimatedConfirmedAt: '2022-10-26T13:10:47.000Z',
                 transactionHash:
-                  '0x66e4a48938f0772aa68f09c504c8b95b65bdde6936d9d0ad46caa4348debbb2e',
+                  '0x8a8de0aeb429dda58b357d6e68ebf15ba45cc7e430967ac4a6984f0dacfe9cb1',
                 token: {
                   contract: {
                     address: '0x60e4d786628fea6478f785a6d7e704777c86a7c6',
                   },
-                  tokenId: '3191',
+                  tokenId: '20898',
                 },
               },
               {
-                blockNumber: 15818432,
-                type: 'TRANSFER',
-                fromAddress: '0xfb279520641bb50d7e8d6be12d790e6e4e00843e',
-                toAddress: '0x8da42a17bece2d99172d04f65b6bc4ab29a492f0',
-                estimatedConfirmedAt: '2022-10-24T14:02:59.000Z',
+                blockNumber: 15832456,
+                type: 'ORDER',
+                fromAddress: '0x32c8b7563e69b57ef29d1c44616bc340848174fd',
+                toAddress: '0x42f61c5f5504807b18e9ba30a6535848627b7a5b',
+                estimatedConfirmedAt: '2022-10-26T13:10:11.000Z',
                 transactionHash:
-                  '0xbc520f82de2c7b6c5e75dd85d85d3174545af979e4dd0b53b78c1041801e0946',
+                  '0x891d2be2509da6e01e36cd13ae164f4788c20e95e624e77bf7d8ca048592a914',
                 token: {
                   contract: {
                     address: '0x60e4d786628fea6478f785a6d7e704777c86a7c6',
                   },
-                  tokenId: '7414',
+                  tokenId: '14008',
                 },
+                marketplace: 'OPENSEA',
+                priceInEth: 15,
               },
             ],
           },
@@ -63,9 +63,7 @@ describe('getContractEventLogs', () => {
 
   it('executes correctly with one type', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getContractEventLogs-onetype',
-      },
+      { recordingName: 'query-getContractEventLogs-onetype' },
       async () => {
         const { data } = await client.nft.getContractEventLogs({
           address: '0x60E4d786628Fea6478F785A6d7e704777c86a7c6',
@@ -118,9 +116,7 @@ describe('getContractEventLogs', () => {
   });
   it('executes correctly with default types', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getContractEventLogs-default',
-      },
+      { recordingName: 'query-getContractEventLogs-default' },
       async () => {
         const { data } = await client.nft.getContractEventLogs({
           address: '0x60E4d786628Fea6478F785A6d7e704777c86a7c6',
@@ -135,34 +131,36 @@ describe('getContractEventLogs', () => {
             },
             logs: [
               {
-                blockNumber: 15818499,
+                blockNumber: 15832459,
                 type: 'TRANSFER',
-                fromAddress: '0xf6cbddd9c1fd75a7760937a320f1da0fac1e58b9',
-                toAddress: '0xdd687258cfb63a8774738d75ae3cc13e79107026',
-                estimatedConfirmedAt: '2022-10-24T14:16:59.000Z',
+                fromAddress: '0xc0df18d3c0dff4580a96c1a2f046c9dcca7aa704',
+                toAddress: '0x8252df1d8b29057d1afe3062bf5a64d503152bc8',
+                estimatedConfirmedAt: '2022-10-26T13:10:47.000Z',
                 transactionHash:
-                  '0x66e4a48938f0772aa68f09c504c8b95b65bdde6936d9d0ad46caa4348debbb2e',
+                  '0x8a8de0aeb429dda58b357d6e68ebf15ba45cc7e430967ac4a6984f0dacfe9cb1',
                 token: {
                   contract: {
                     address: '0x60e4d786628fea6478f785a6d7e704777c86a7c6',
                   },
-                  tokenId: '3191',
+                  tokenId: '20898',
                 },
               },
               {
-                blockNumber: 15818432,
-                type: 'TRANSFER',
-                fromAddress: '0xfb279520641bb50d7e8d6be12d790e6e4e00843e',
-                toAddress: '0x8da42a17bece2d99172d04f65b6bc4ab29a492f0',
-                estimatedConfirmedAt: '2022-10-24T14:02:59.000Z',
+                blockNumber: 15832456,
+                type: 'ORDER',
+                fromAddress: '0x32c8b7563e69b57ef29d1c44616bc340848174fd',
+                toAddress: '0x42f61c5f5504807b18e9ba30a6535848627b7a5b',
+                estimatedConfirmedAt: '2022-10-26T13:10:11.000Z',
                 transactionHash:
-                  '0xbc520f82de2c7b6c5e75dd85d85d3174545af979e4dd0b53b78c1041801e0946',
+                  '0x891d2be2509da6e01e36cd13ae164f4788c20e95e624e77bf7d8ca048592a914',
                 token: {
                   contract: {
                     address: '0x60e4d786628fea6478f785a6d7e704777c86a7c6',
                   },
-                  tokenId: '7414',
+                  tokenId: '14008',
                 },
+                marketplace: 'OPENSEA',
+                priceInEth: 15,
               },
             ],
           },
@@ -173,9 +171,7 @@ describe('getContractEventLogs', () => {
 
   it('can iterate logs', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getContractEventLogs-iterate',
-      },
+      { recordingName: 'query-getContractEventLogs-iterate' },
       async () => {
         const { data: firstResponse } = await client.nft.getContractEventLogs({
           address: '0x2106C00Ac7dA0A3430aE667879139E832307AeAa',
@@ -195,6 +191,23 @@ describe('getContractEventLogs', () => {
             },
             logs: [
               {
+                blockNumber: 15819560,
+                type: 'ORDER',
+                fromAddress: '0x3082a2dd0028231423a5fb470407a89c024b308d',
+                toAddress: '0x3f64317f0ed628bce5575892f96d9cd52f1c30ba',
+                estimatedConfirmedAt: '2022-10-24T17:52:47.000Z',
+                transactionHash:
+                  '0xaeb625b739248780d60250eb76fbce3a3a494c0e64a61d3636ad4575106fdc92',
+                token: {
+                  contract: {
+                    address: '0x2106c00ac7da0a3430ae667879139e832307aeaa',
+                  },
+                  tokenId: '6531',
+                },
+                marketplace: 'OPENSEA',
+                priceInEth: 0.01,
+              },
+              {
                 blockNumber: 15804550,
                 type: 'ORDER',
                 fromAddress: '0x30879cf3c26a5abc9fc7fc82e39bd47dd5daeb54',
@@ -211,6 +224,17 @@ describe('getContractEventLogs', () => {
                 marketplace: 'OPENSEA',
                 priceInEth: 0.0095,
               },
+            ],
+          },
+        });
+        expect(secondResponse).toStrictEqual({
+          contract: {
+            address: '0x2106c00ac7da0a3430ae667879139e832307aeaa',
+            logsPageInfo: {
+              hasNextPage: true,
+              endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
+            },
+            logs: [
               {
                 blockNumber: 15803813,
                 type: 'TRANSFER',
@@ -226,17 +250,6 @@ describe('getContractEventLogs', () => {
                   tokenId: '8845',
                 },
               },
-            ],
-          },
-        });
-        expect(secondResponse).toStrictEqual({
-          contract: {
-            address: '0x2106c00ac7da0a3430ae667879139e832307aeaa',
-            logsPageInfo: {
-              hasNextPage: true,
-              endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
-            },
-            logs: [
               {
                 blockNumber: 15794055,
                 type: 'TRANSFER',
@@ -252,23 +265,6 @@ describe('getContractEventLogs', () => {
                   tokenId: '8981',
                 },
               },
-              {
-                blockNumber: 15790053,
-                type: 'ORDER',
-                fromAddress: '0xc6eab1b834647bbdc18f42d33a791fb1fac73e58',
-                toAddress: '0xf4367ed4dbd13e5348b11436d3805ac8db20d9ce',
-                estimatedConfirmedAt: '2022-10-20T14:58:11.000Z',
-                transactionHash:
-                  '0x6c509fe0c92208ac60bdf8fec20e4054005e19bc85702d6ec3d421719b0c0bb6',
-                token: {
-                  contract: {
-                    address: '0x2106c00ac7da0a3430ae667879139e832307aeaa',
-                  },
-                  tokenId: '766',
-                },
-                marketplace: 'OPENSEA',
-                priceInEth: 0.01,
-              },
             ],
           },
         });
@@ -278,9 +274,7 @@ describe('getContractEventLogs', () => {
 
   it('can handle null response', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getContractEventLogs-null',
-      },
+      { recordingName: 'query-getContractEventLogs-null' },
       async () => {
         const { data } = await client.nft.getContractEventLogs({
           address: '0x11111111111110thisisnotanaddress01111111',

--- a/packages/libs/api/sdk/src/queries/nft/getNFTEventLogs/getNFTEventLogs.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getNFTEventLogs/getNFTEventLogs.spec.ts
@@ -8,7 +8,6 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-alltypes',
-        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -58,7 +57,6 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-onetype',
-        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -96,7 +94,6 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-notypes',
-        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -145,7 +142,6 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-iterate',
-        recordIfMissing: true,
       },
       async () => {
         const { data: firstResponse } = await client.nft.getNFTEventLogs({
@@ -233,7 +229,6 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-null',
-        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({

--- a/packages/libs/api/sdk/src/queries/nft/getNFTEventLogs/getNFTEventLogs.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getNFTEventLogs/getNFTEventLogs.spec.ts
@@ -8,6 +8,7 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-alltypes',
+        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -57,6 +58,7 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-onetype',
+        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -94,6 +96,7 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-notypes',
+        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({
@@ -142,6 +145,7 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-iterate',
+        recordIfMissing: true,
       },
       async () => {
         const { data: firstResponse } = await client.nft.getNFTEventLogs({
@@ -229,6 +233,7 @@ describe('getNFTEventLogs', () => {
     await withPolly(
       {
         recordingName: 'query-getEventLogs-null',
+        recordIfMissing: true,
       },
       async () => {
         const { data } = await client.nft.getNFTEventLogs({

--- a/packages/libs/api/sdk/src/queries/nft/getNFTsByContractAddress/getNFTsByContractAddress.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getNFTsByContractAddress/getNFTsByContractAddress.spec.ts
@@ -6,9 +6,7 @@ const client = new QuickNodeSDK();
 describe('getNFTsByContractAddress', () => {
   it('executes correctly', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getNFTsByContractAddress-base',
-      },
+      { recordingName: 'query-getNFTsByContractAddress-base' },
       async () => {
         const { data } = await client.nft.getNFTsByContractAddress({
           address: '0x2106C00Ac7dA0A3430aE667879139E832307AeAa',

--- a/packages/libs/api/sdk/src/queries/nft/getNFTsByWalletAndContracts/getNFTsByWalletAndContracts.spec.ts
+++ b/packages/libs/api/sdk/src/queries/nft/getNFTsByWalletAndContracts/getNFTsByWalletAndContracts.spec.ts
@@ -6,13 +6,11 @@ const client = new QuickNodeSDK();
 describe('getNFTsByWalletAndContracts', () => {
   it('can query one contract', async () => {
     await withPolly(
-      {
-        recordingName: 'query-NFTbyWalletAndContract-base',
-      },
+      { recordingName: 'query-NFTbyWalletAndContract-base' },
       async () => {
         const { data } = await client.nft.getNFTsByWalletAndContracts({
-          address: '0x13928eb9a86c8278a45b6ff2935c7730b58ac675',
-          contracts: ['0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d'],
+          address: '0x13928eB9A86c8278a45B6fF2935c7730b58AC675',
+          contracts: ['0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D'],
           first: 2,
         });
 
@@ -84,15 +82,13 @@ describe('getNFTsByWalletAndContracts', () => {
 
   it('can query multiple contracts', async () => {
     await withPolly(
-      {
-        recordingName: 'query-NFTbyWalletAndContract-multiple',
-      },
+      { recordingName: 'query-NFTbyWalletAndContract-multiple' },
       async () => {
         const { data } = await client.nft.getNFTsByWalletAndContracts({
-          address: '0x13928eb9a86c8278a45b6ff2935c7730b58ac675',
+          address: '0x13928eB9A86c8278a45B6fF2935c7730b58AC675',
           contracts: [
-            '0xba30e5f9bb24caa003e9f2f0497ad287fdf95623',
-            '0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e',
+            '0xba30E5F9Bb24caa003E9f2f0497Ad287FDF95623',
+            '0xbCe3781ae7Ca1a5e050Bd9C4c77369867eBc307e',
           ],
           first: 2,
         });
@@ -165,21 +161,19 @@ describe('getNFTsByWalletAndContracts', () => {
 
   it('can iterate results', async () => {
     await withPolly(
-      {
-        recordingName: 'query-NFTByWalletAndContract-iterate',
-      },
+      { recordingName: 'query-NFTByWalletAndContract-iterate' },
       async () => {
         const { data: firstResult } =
           await client.nft.getNFTsByWalletAndContracts({
-            address: '0x13928eb9a86c8278a45b6ff2935c7730b58ac675',
-            contracts: ['0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d'],
+            address: '0x13928eB9A86c8278a45B6fF2935c7730b58AC675',
+            contracts: ['0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D'],
             first: 2,
           });
 
         const { data: secondResult } =
           await client.nft.getNFTsByWalletAndContracts({
-            address: '0x13928eb9a86c8278a45b6ff2935c7730b58ac675',
-            contracts: ['0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d'],
+            address: '0x13928eB9A86c8278a45B6fF2935c7730b58AC675',
+            contracts: ['0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D'],
             first: 2,
             after: 'YXJyYXljb25uZWN0aW9uOjE=',
           });
@@ -315,9 +309,7 @@ describe('getNFTsByWalletAndContracts', () => {
 
   it('can handle null result', async () => {
     await withPolly(
-      {
-        recordingName: 'query-getByWalletAndContract-null',
-      },
+      { recordingName: 'query-getByWalletAndContract-null' },
       async () => {
         const { data } = await client.nft.getNFTsByWalletAndContracts({
           address: '0x11111111111110thisisnotanaddress01111111',

--- a/packages/libs/api/sdk/src/queries/nft/nftQueries.ts
+++ b/packages/libs/api/sdk/src/queries/nft/nftQueries.ts
@@ -53,7 +53,7 @@ export class NFTQueries {
     return await this.client.query({
       query: getWalletAddressNFTsRawQuery,
       variables: {
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         ...otherVariables,
       },
     });
@@ -75,7 +75,7 @@ export class NFTQueries {
     return await this.client.query({
       query: getContractAddressNFTsRawQuery,
       variables: {
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         ...otherVariables,
       },
     });
@@ -88,7 +88,7 @@ export class NFTQueries {
     return await this.client.query({
       query: getCollectionDetailsRawQuery,
       variables: {
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         ...otherVariables,
       },
     });
@@ -106,7 +106,7 @@ export class NFTQueries {
       query: getNFTEventLogsRawQuery,
       variables: {
         ...otherVariables,
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         filter: {
           typeIn: types,
         },
@@ -121,7 +121,7 @@ export class NFTQueries {
     return await this.client.query({
       query: getNFTDetailsRawQuery,
       variables: {
-        contractAddress: contractAddress.toLowerCase(), // handling an icy API case-sensitive bug
+        contractAddress: contractAddress.toLowerCase(),
         ...otherVariables,
       },
     });
@@ -139,7 +139,7 @@ export class NFTQueries {
       query: getContractEventLogsRawQuery,
       variables: {
         ...otherVariables,
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         filter: {
           typeIn: types,
         },
@@ -151,14 +151,14 @@ export class NFTQueries {
     variables: NFTWalletAndContractQueryVariables
   ): Promise<ApolloQueryResult<WalletNFTsQueryResponse>> {
     const { address, contracts, ...otherVariables } = variables;
-    const normalizedContracts = contracts.map(
-      (contract) => contract.toLowerCase() // handling an icy API case-sensitive bug
+    const normalizedContracts = contracts.map((contract) =>
+      contract.toLowerCase()
     );
     const response = await this.client.query({
       query: getNFTsWalletAndContractsRawQuery,
       variables: {
         ...otherVariables,
-        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        address: address.toLowerCase(),
         filter: { contractAddressIn: normalizedContracts },
       },
     });

--- a/packages/libs/api/sdk/src/queries/nft/nftQueries.ts
+++ b/packages/libs/api/sdk/src/queries/nft/nftQueries.ts
@@ -49,9 +49,13 @@ export class NFTQueries {
   async getNFTsByWalletAddress(
     variables: WalletAddressNFTsQueryVariables
   ): Promise<ApolloQueryResult<WalletNFTsQueryResponse>> {
+    const { address, ...otherVariables } = variables;
     return await this.client.query({
       query: getWalletAddressNFTsRawQuery,
-      variables,
+      variables: {
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        ...otherVariables,
+      },
     });
   }
 
@@ -67,29 +71,42 @@ export class NFTQueries {
   async getNFTsByContractAddress(
     variables: ContractAddressNFTsQueryVariables
   ): Promise<ApolloQueryResult<ContractNFTsQueryResponse>> {
+    const { address, ...otherVariables } = variables;
     return await this.client.query({
       query: getContractAddressNFTsRawQuery,
-      variables,
+      variables: {
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        ...otherVariables,
+      },
     });
   }
 
   async getCollectionDetails(
     variables: CollectionDetailsQueryVariables
   ): Promise<ApolloQueryResult<CollectionDetailsQueryResponse>> {
+    const { address, ...otherVariables } = variables;
     return await this.client.query({
       query: getCollectionDetailsRawQuery,
-      variables,
+      variables: {
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        ...otherVariables,
+      },
     });
   }
 
   async getNFTEventLogs(
     variables: EventLogsQueryVariables
   ): Promise<ApolloQueryResult<EventLogsQueryResponse>> {
-    const { types = DEFAULT_LOG_FILTER_TYPES, ...otherVariables } = variables;
+    const {
+      address,
+      types = DEFAULT_LOG_FILTER_TYPES,
+      ...otherVariables
+    } = variables;
     return await this.client.query({
       query: getNFTEventLogsRawQuery,
       variables: {
         ...otherVariables,
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
         filter: {
           typeIn: types,
         },
@@ -100,20 +117,29 @@ export class NFTQueries {
   async getNFTDetails(
     variables: NFTDetailsQueryVariables
   ): Promise<ApolloQueryResult<NFTDetailsQueryResponse>> {
+    const { contractAddress, ...otherVariables } = variables;
     return await this.client.query({
       query: getNFTDetailsRawQuery,
-      variables,
+      variables: {
+        contractAddress: contractAddress.toLowerCase(), // handling an icy API case-sensitive bug
+        ...otherVariables,
+      },
     });
   }
 
   async getContractEventLogs(
     variables: ContractEventLogQueryVariables
   ): Promise<ApolloQueryResult<ContractEventLogsQueryResponse>> {
-    const { types = DEFAULT_LOG_FILTER_TYPES, ...otherVariables } = variables;
+    const {
+      address,
+      types = DEFAULT_LOG_FILTER_TYPES,
+      ...otherVariables
+    } = variables;
     return await this.client.query({
       query: getContractEventLogsRawQuery,
       variables: {
         ...otherVariables,
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
         filter: {
           typeIn: types,
         },
@@ -124,12 +150,16 @@ export class NFTQueries {
   async getNFTsByWalletAndContracts(
     variables: NFTWalletAndContractQueryVariables
   ): Promise<ApolloQueryResult<WalletNFTsQueryResponse>> {
-    const { contracts, ...otherVariables } = variables;
+    const { address, contracts, ...otherVariables } = variables;
+    const normalizedContracts = contracts.map(
+      (contract) => contract.toLowerCase() // handling an icy API case-sensitive bug
+    );
     const response = await this.client.query({
       query: getNFTsWalletAndContractsRawQuery,
       variables: {
         ...otherVariables,
-        filter: { contractAddressIn: contracts },
+        address: address.toLowerCase(), // handling an icy API case-sensitive bug
+        filter: { contractAddressIn: normalizedContracts },
       },
     });
     return response;


### PR DESCRIPTION
I updated `packages/libs/api/sdk/src/queries/nft/nftQueries.ts` to normalize addresses to lowercase since that seems to be the most consistent for icy tools API. We maybe could break this into a `normalizeVariables` helper function or similar, but essentially it's just doing `.toLowerCase()`, so I'm on the fence about that 🤔 

Many tests had to be re-recorded because the input is now lower-cased, and some of the data changed so the responses had to be updated