### PR TITLE
[SC-44550] Readme updates and badge fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # QuickNode OSS Repository
 
+[QuickNode](https://www.quicknode.com/)'s open-source monorepo
+
 ## Packages
 
 - [QuickNode SDK](./packages/libs/api/sdk/README.md): Framework agnostic library that serves as a wrapper to QuickNode's APIs, currently supports [icy.tools GraphQL API](https://developers.icy.tools).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # QuickNode OSS Repository
 
-## Apps
-
-- [nft-react-hooks example](./packages/apps/examples/nft-react-hooks)
-- [nft-sdk example](./packages/apps/examples/nft-sdk/)
-
 ## Packages
 
 - [QuickNode SDK](./packages/libs/api/sdk/README.md): Framework agnostic library that serves as a wrapper to QuickNode's APIs, currently supports [icy.tools GraphQL API](https://developers.icy.tools).
 - [nft-react-hooks](./packages/libs/ui/nft-react-hooks/README.md): React hook library that serves as a wrapper to the [icy.tools GraphQL API](https://developers.icy.tools).
+
+## Apps
+
+- [nft-react-hooks example](./packages/apps/examples/nft-react-hooks)
+- [nft-sdk example](./packages/apps/examples/nft-sdk/)

--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -4,12 +4,12 @@ An SDK from [QuickNode](https://www.quicknode.com/) making it easy for developer
 
 Currently this has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
 
-[![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat-square)](https://www.npmjs.com/package/@quicknode/sdk)
-[![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat-square)](https://www.npmjs.com/package/@quicknode/sdk)
-![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g&style=flat-square)
-[![License](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat-square)](https://github.com/quiknode-labs/qn-oss/blob/main/LICENSE.txt)
-[![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g&style=flat-square)](https://github.com/quiknode-labs/qn-oss/issues)
-[![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat-square)](https://discord.gg/DkdgEqE)
+[![npm](https://img.shields.io/npm/dm/@quicknode/sdk)](https://www.npmjs.com/package/@quicknode/sdk)
+[![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g)](https://www.npmjs.com/package/@quicknode/sdk)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g)
+[![License](https://img.shields.io/npm/l/@quicknode/sdk?color=g)](https://github.com/quiknode-labs/qn-oss/blob/main/LICENSE.txt)
+[![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g)](https://github.com/quiknode-labs/qn-oss/issues)
+[![Discord](https://img.shields.io/discord/880505845090250794?color=g)](https://discord.gg/DkdgEqE)
 
 ## Quick Start
 

--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -6,12 +6,12 @@ A way to Currently has support for getting started with [Icy Tools GraphQL API](
 [![NPM Install Size][npm-install-size-image]][npm-install-size-url]
 [![NPM Downloads][npm-downloads-image]][npm-downloads-url]
 
-![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat)
-![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat)
-![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g&style=flat)
-![NPM](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat)
-![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g)
-![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat)
+![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat-square)
+![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat-square)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g&style=flat-square)
+![NPM](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat-square)
+![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g&style=flat-square)
+![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat-square)
 
 ## Quick Start
 

--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -2,7 +2,7 @@
 
 An SDK from [QuickNode](https://www.quicknode.com/) making it easy for developers to interact with the blockchain.
 
-Currently this has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
+Currently supports getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
 
 [![npm](https://img.shields.io/npm/dm/@quicknode/sdk)](https://www.npmjs.com/package/@quicknode/sdk)
 [![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g)](https://www.npmjs.com/package/@quicknode/sdk)

--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -1,13 +1,17 @@
-![npm](https://img.shields.io/npm/dm/@quicknode/sdk)
-![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g)
-![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g)
-![NPM](https://img.shields.io/npm/l/@quicknode/sdk?color=g)
-![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g)
-![Discord](https://img.shields.io/discord/880505845090250794?color=g)
-
 # QuickNode SDK
 
-Currently has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
+A way to Currently has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
+
+[![NPM Version][npm-version-image]][npm-url]
+[![NPM Install Size][npm-install-size-image]][npm-install-size-url]
+[![NPM Downloads][npm-downloads-image]][npm-downloads-url]
+
+![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat)
+![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g&style=flat)
+![NPM](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat)
+![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g)
+![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat)
 
 ## Quick Start
 

--- a/packages/libs/api/sdk/README.md
+++ b/packages/libs/api/sdk/README.md
@@ -1,17 +1,15 @@
 # QuickNode SDK
 
-A way to Currently has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
+An SDK from [QuickNode](https://www.quicknode.com/) making it easy for developers to interact with the blockchain.
 
-[![NPM Version][npm-version-image]][npm-url]
-[![NPM Install Size][npm-install-size-image]][npm-install-size-url]
-[![NPM Downloads][npm-downloads-image]][npm-downloads-url]
+Currently this has support for getting started with [Icy Tools GraphQL API](https://developers.icy.tools/) in a blink!
 
-![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat-square)
-![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat-square)
+[![npm](https://img.shields.io/npm/dm/@quicknode/sdk?style=flat-square)](https://www.npmjs.com/package/@quicknode/sdk)
+[![npm](https://img.shields.io/npm/v/@quicknode/sdk?color=g&style=flat-square)](https://www.npmjs.com/package/@quicknode/sdk)
 ![Maintenance](https://img.shields.io/maintenance/yes/2022?color=g&style=flat-square)
-![NPM](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat-square)
-![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g&style=flat-square)
-![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat-square)
+[![License](https://img.shields.io/npm/l/@quicknode/sdk?color=g&style=flat-square)](https://github.com/quiknode-labs/qn-oss/blob/main/LICENSE.txt)
+[![GitHub issues](https://img.shields.io/github/issues-raw/quiknode-labs/qn-oss?color=g&style=flat-square)](https://github.com/quiknode-labs/qn-oss/issues)
+[![Discord](https://img.shields.io/discord/880505845090250794?color=g&style=flat-square)](https://discord.gg/DkdgEqE)
 
 ## Quick Start
 
@@ -259,6 +257,10 @@ client.nft.getNFTsByWalletENS({
 ```
 
 # Contributing corner
+
+## Issues
+
+Please submit any questions, issues, or feedback as an [issue in Github](https://github.com/quiknode-labs/qn-oss/issues).
 
 ## Building
 


### PR DESCRIPTION
I updated the READMEs and made some changes to the badges.

For the main README, I moved the packages to the top, since we want to feature the SDK, and added a small description line to it.

For the SDK README, I added a general description, and  moved the badges below the description and title so they don't show in the link preview. Express [has a similar structure](https://www.npmjs.com/package/express)
<img width="627" alt="Screen Shot 2022-10-28 at 11 44 07 AM" src="https://user-images.githubusercontent.com/5964462/198678578-8ebc0db8-7437-4768-91d0-9b76b4fe0a02.png">

I originally set out to fix the broken badges on NPM, but they seem to be fixed now, maybe they are now cached somewhere since I kept reloading and visiting the page 🤷🏻‍♂️  I did add links to the badges so they can be clicked on

<img width="687" alt="Screen Shot 2022-10-28 at 11 47 49 AM" src="https://user-images.githubusercontent.com/5964462/198679326-485ea6bc-298a-4610-9ba5-b557bf3ee133.png">
