### PR TITLE
Export types for inputs and outputs of functions

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-beta.0",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",

--- a/packages/libs/sdk/src/api/controllers/contracts.ts
+++ b/packages/libs/sdk/src/api/controllers/contracts.ts
@@ -1,12 +1,12 @@
 import { CustomUrqlClient } from '../graphql/customUrqlClient';
 import { ChainName } from '../types/chains';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 import {
-  ContractDetailsFormattedResult,
+  ContractDetailsResult,
   ContractDetailsQueryResultFull,
-  ContractDetailsQueryVariablesType,
-  ContractDetailsQueryType,
+  ContractDetailsQueryVariables,
+  ContractDetailsQuery,
+  ContractDetailsInput,
 } from '../types/contracts/getContractDetails';
 import {
   CodegenEthMainnetContractDetailsDocument,
@@ -22,8 +22,8 @@ export class ContractsController {
   ) {}
 
   async getDetails(
-    variables: ContractDetailsQueryVariablesType & NonQueryInput
-  ): Promise<ContractDetailsFormattedResult> {
+    variables: ContractDetailsInput
+  ): Promise<ContractDetailsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -37,8 +37,8 @@ export class ContractsController {
         [userChain]: { contract },
       },
     } = await this.client.query<
-      ContractDetailsQueryVariablesType,
-      ContractDetailsQueryType,
+      ContractDetailsQueryVariables,
+      ContractDetailsQuery,
       ContractDetailsQueryResultFull
     >({
       variables: queryVariables,

--- a/packages/libs/sdk/src/api/controllers/events.ts
+++ b/packages/libs/sdk/src/api/controllers/events.ts
@@ -2,8 +2,9 @@ import {
   ContractEventsQueryResultInfo,
   ContractEventsFormattedResult,
   ContractEventsQueryResultFull,
-  ContractEventsQueryVariablesType,
-  ContractEventsQueryType,
+  ContractEventsQueryVariables,
+  ContractEventsQuery,
+  ContractEventsInput,
 } from '../types/events/getByContract';
 import {
   CollectionEventsQueryResultInfo,
@@ -21,10 +22,11 @@ import {
 } from '../types/nfts/getNFTEvents';
 import {
   AllEventsQueryResultInfo,
-  AllEventsFormattedResult,
+  AllEventsResult,
   AllEventsQueryResultFull,
-  AllEventsQueryVariablesType,
-  AllEventsQueryType,
+  AllEventsQueryVariables,
+  AllEventsQuery,
+  AllEventsInput,
 } from '../types/events/getAll';
 import {
   CodegenEthereumMainnetEventsByContractDocument,
@@ -170,9 +172,7 @@ export class EventsController {
     return formattedResult;
   }
 
-  async getAll(
-    variables: AllEventsQueryVariablesType & NonQueryInput
-  ): Promise<AllEventsFormattedResult> {
+  async getAll(variables: AllEventsInput): Promise<AllEventsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -184,8 +184,8 @@ export class EventsController {
     const {
       data: { [userChain]: tokenEvents },
     } = await this.client.query<
-      AllEventsQueryVariablesType,
-      AllEventsQueryType,
+      AllEventsQueryVariables,
+      AllEventsQuery,
       AllEventsQueryResultFull
     >({
       query: query[userChain],
@@ -194,7 +194,7 @@ export class EventsController {
 
     const formattedResult = formatQueryResult<
       AllEventsQueryResultInfo,
-      AllEventsFormattedResult
+      AllEventsResult
     >(tokenEvents, 'tokenEvents', 'tokenEventsPageInfo');
 
     return formattedResult;

--- a/packages/libs/sdk/src/api/controllers/events.ts
+++ b/packages/libs/sdk/src/api/controllers/events.ts
@@ -1,6 +1,6 @@
 import {
   ContractEventsQueryResultInfo,
-  ContractEventsFormattedResult,
+  ContractEventsResult,
   ContractEventsQueryResultFull,
   ContractEventsQueryVariables,
   ContractEventsQuery,
@@ -8,17 +8,19 @@ import {
 } from '../types/events/getByContract';
 import {
   CollectionEventsQueryResultInfo,
-  CollectionEventsFormattedResult,
+  CollectionEventsResult,
   CollectionEventsQueryResultFull,
-  CollectionEventsQueryVariablesType,
-  CollectionEventsQueryType,
+  CollectionEventsQueryVariables,
+  CollectionEventsQuery,
+  CollectionEventsInput,
 } from '../types/nfts/getCollectionEvents';
 import {
   NFTEventsQueryResultInfo,
-  NFTEventsFormattedResult,
+  NFTEventsResult,
   NFTEventsQueryResultFull,
-  NFTEventsQueryVariablesType,
-  NFTEventsQueryType,
+  NFTEventsQueryVariables,
+  NFTEventsQuery,
+  NFTEventsInput,
 } from '../types/nfts/getNFTEvents';
 import {
   AllEventsQueryResultInfo,
@@ -48,7 +50,6 @@ import { formatQueryResult } from '../utils/postQueryFormatter';
 import { emptyPageInfo } from '../utils/helpers';
 import { TypedDocumentNode } from '@urql/core';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 
 export class EventsController {
   constructor(
@@ -57,8 +58,8 @@ export class EventsController {
   ) {}
 
   async getByContract(
-    variables: ContractEventsQueryVariablesType & NonQueryInput
-  ): Promise<ContractEventsFormattedResult> {
+    variables: ContractEventsInput
+  ): Promise<ContractEventsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -72,8 +73,8 @@ export class EventsController {
         [userChain]: { contract },
       },
     } = await this.client.query<
-      ContractEventsQueryVariablesType,
-      ContractEventsQueryType,
+      ContractEventsQueryVariables,
+      ContractEventsQuery,
       ContractEventsQueryResultFull
     >({
       query: query[userChain],
@@ -89,15 +90,15 @@ export class EventsController {
 
     const formattedResult = formatQueryResult<
       ContractEventsQueryResultInfo,
-      ContractEventsFormattedResult
+      ContractEventsResult
     >(contract, 'tokenEvents', 'tokenEventsPageInfo');
 
     return formattedResult;
   }
 
   async getByNFTCollection(
-    variables: CollectionEventsQueryVariablesType & NonQueryInput
-  ): Promise<CollectionEventsFormattedResult> {
+    variables: CollectionEventsInput
+  ): Promise<CollectionEventsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -110,8 +111,8 @@ export class EventsController {
         [userChain]: { collection },
       },
     } = await this.client.query<
-      CollectionEventsQueryVariablesType, // What the user can pass in
-      CollectionEventsQueryType, // The actual unmodified result from query
+      CollectionEventsQueryVariables, // What the user can pass in
+      CollectionEventsQuery, // The actual unmodified result from query
       CollectionEventsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -121,21 +122,19 @@ export class EventsController {
     if (!collection?.tokenEvents?.length)
       return { results: [], pageInfo: emptyPageInfo };
 
-    function removeKeyFields(results: any): CollectionEventsFormattedResult {
+    function removeKeyFields(results: any): CollectionEventsResult {
       const { address, ...newResults } = results;
       return newResults;
     }
     const formattedResult = formatQueryResult<
       CollectionEventsQueryResultInfo,
-      CollectionEventsFormattedResult
+      CollectionEventsResult
     >(collection, 'tokenEvents', 'tokenEventsPageInfo', null, removeKeyFields);
 
     return formattedResult;
   }
 
-  async getByNFT(
-    variables: NFTEventsQueryVariablesType & NonQueryInput
-  ): Promise<NFTEventsFormattedResult> {
+  async getByNFT(variables: NFTEventsInput): Promise<NFTEventsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -148,8 +147,8 @@ export class EventsController {
         [userChain]: { nft },
       },
     } = await this.client.query<
-      NFTEventsQueryVariablesType, // What the user can pass in
-      NFTEventsQueryType, // The actual unmodified result from query
+      NFTEventsQueryVariables, // What the user can pass in
+      NFTEventsQuery, // The actual unmodified result from query
       NFTEventsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -159,14 +158,14 @@ export class EventsController {
     if (!nft?.tokenEvents?.length)
       return { results: [], pageInfo: emptyPageInfo };
 
-    function removeKeyFields(results: any): NFTEventsFormattedResult {
+    function removeKeyFields(results: any): NFTEventsResult {
       const { contractAddress, tokenId, ...newResults } = results;
       return newResults;
     }
 
     const formattedResult = formatQueryResult<
       NFTEventsQueryResultInfo,
-      NFTEventsFormattedResult
+      NFTEventsResult
     >(nft, 'tokenEvents', 'tokenEventsPageInfo', null, removeKeyFields);
 
     return formattedResult;

--- a/packages/libs/sdk/src/api/controllers/nfts.ts
+++ b/packages/libs/sdk/src/api/controllers/nfts.ts
@@ -6,7 +6,7 @@ import {
   WalletNFTsByEnsQueryResultFull,
   WalletNFTsByEnsQueryVariables,
   WalletNFTsByEnsQuery,
-  WalletNFTsByENSInput,
+  WalletNFTsByEnsInput,
 } from '../types/nfts/getByWalletENS';
 import {
   WalletNFTsByAddressQueryResultInfo,
@@ -99,7 +99,7 @@ export class NftsController {
   }
 
   private async getByWalletENS(
-    variables: WalletNFTsByENSInput
+    variables: WalletNFTsByEnsInput
   ): Promise<WalletNFTsByEnsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;

--- a/packages/libs/sdk/src/api/controllers/nfts.ts
+++ b/packages/libs/sdk/src/api/controllers/nfts.ts
@@ -2,43 +2,49 @@ import { CustomUrqlClient } from '../graphql/customUrqlClient';
 
 import {
   WalletNFTsByEnsQueryResultInfo,
-  WalletNFTsByEnsFormattedResult,
+  WalletNFTsByEnsResult,
   WalletNFTsByEnsQueryResultFull,
-  WalletNFTsByEnsQueryVariablesType,
-  WalletNFTsByEnsQueryType,
+  WalletNFTsByEnsQueryVariables,
+  WalletNFTsByEnsQuery,
+  WalletNFTsByENSInput,
 } from '../types/nfts/getByWalletENS';
 import {
   WalletNFTsByAddressQueryResultInfo,
-  WalletNFTsByAddressFormattedResult,
+  WalletNFTsByAddressResult,
   WalletNFTByAddressQueryResultFull,
-  WalletNFTsByAddressQueryVariablesType,
-  WalletNFTsByAddressQueryType,
+  WalletNFTsByAddressQueryVariables,
+  WalletNFTsByAddressQuery,
+  WalletNFTsByAddressInput,
 } from '../types/nfts/getByWalletAddress';
 import {
-  NFTDetailsFormattedResult,
+  NFTDetailsResult,
   NFTDetailsQueryResultFull,
-  NFTDetailsQueryVariablesType,
-  NFTDetailsQueryType,
+  NFTDetailsQueryVariables,
+  NFTDetailsQuery,
+  NFTDetailsInput,
 } from '../types/nfts/getNFTDetails';
 import {
-  NftCollectionDetailsFormattedResult,
+  NftCollectionDetailsResult,
   NftCollectionDetailsQueryResultFull,
-  NftCollectionDetailsQueryVariablesType,
-  NftCollectionDetailsQueryType,
+  NftCollectionDetailsQueryVariables,
+  NftCollectionDetailsQuery,
+  NftCollectionDetailsInput,
 } from '../types/nfts/getCollectionDetails';
 import {
   NFTTrendingCollectionsQueryResultBody,
-  NFTTrendingCollectionFormattedResult,
+  NFTTrendingCollectionResult,
   NFTTrendingCollectionsQueryResultFull,
-  NFTTrendingCollectionsQueryVariablesType,
-  NFTTrendingCollectionsQueryType,
+  NFTTrendingCollectionsQueryVariables,
+  NFTTrendingCollectionsQuery,
+  NFTTrendingCollectionsInput,
 } from '../types/nfts/getTrendingCollections';
 import {
   NFTsByContractAddressQueryResultInfo,
-  NFTsByContractAddressFormattedResult,
+  NFTsByContractAddressResult,
   NFTsByContractAddressQueryResultFull,
-  NFTsByContractAddressQueryVariablesType,
-  NFTsByContractAddressQueryType,
+  NFTsByContractAddressQueryVariables,
+  NFTsByContractAddressQuery,
+  NFTsByContractAddressInput,
 } from '../types/nfts/getByContractAddress';
 
 import {
@@ -66,7 +72,6 @@ import { formatQueryResult } from '../utils/postQueryFormatter';
 import { emptyPageInfo } from '../utils/helpers';
 import { TypedDocumentNode } from '@urql/core';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 import { NftErcStandards } from '../types/nfts';
 import { isValidENSAddress } from '../utils/isValidENSAddress';
 
@@ -77,8 +82,8 @@ export class NftsController {
   ) {}
 
   async getByWallet(
-    variables: WalletNFTsByAddressQueryVariablesType & NonQueryInput
-  ): Promise<WalletNFTsByAddressFormattedResult> {
+    variables: WalletNFTsByAddressInput
+  ): Promise<WalletNFTsByAddressResult> {
     const { address, ...allVariables } = variables;
     if (isValidENSAddress(address)) {
       return this.getByWalletENS({
@@ -94,8 +99,8 @@ export class NftsController {
   }
 
   private async getByWalletENS(
-    variables: WalletNFTsByEnsQueryVariablesType & NonQueryInput
-  ): Promise<WalletNFTsByEnsFormattedResult> {
+    variables: WalletNFTsByENSInput
+  ): Promise<WalletNFTsByEnsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -109,8 +114,8 @@ export class NftsController {
         [userChain]: { walletByENS },
       },
     } = await this.client.query<
-      WalletNFTsByEnsQueryVariablesType, // What the user can pass in
-      WalletNFTsByEnsQueryType, // The actual unmodified result from query
+      WalletNFTsByEnsQueryVariables, // What the user can pass in
+      WalletNFTsByEnsQuery, // The actual unmodified result from query
       WalletNFTsByEnsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -131,15 +136,15 @@ export class NftsController {
 
     const formattedResult = formatQueryResult<
       WalletNFTsByEnsQueryResultInfo,
-      WalletNFTsByEnsFormattedResult
+      WalletNFTsByEnsResult
     >(walletByENS, 'walletNFTs', 'walletNFTsPageInfo', 'nft');
 
     return formattedResult;
   }
 
   private async getByWalletAddress(
-    variables: WalletNFTsByAddressQueryVariablesType & NonQueryInput
-  ): Promise<WalletNFTsByAddressFormattedResult> {
+    variables: WalletNFTsByAddressInput
+  ): Promise<WalletNFTsByAddressResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -153,8 +158,8 @@ export class NftsController {
         [userChain]: { walletByAddress },
       },
     } = await this.client.query<
-      WalletNFTsByAddressQueryVariablesType, // What the user can pass in
-      WalletNFTsByAddressQueryType, // The actual unmodified result from query
+      WalletNFTsByAddressQueryVariables, // What the user can pass in
+      WalletNFTsByAddressQuery, // The actual unmodified result from query
       WalletNFTByAddressQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -174,15 +179,15 @@ export class NftsController {
 
     const formattedResult = formatQueryResult<
       WalletNFTsByAddressQueryResultInfo,
-      WalletNFTsByAddressFormattedResult
+      WalletNFTsByAddressResult
     >(walletByAddress, 'walletNFTs', 'walletNFTsPageInfo', 'nft');
 
     return formattedResult;
   }
 
   async getTrendingCollections(
-    variables: NFTTrendingCollectionsQueryVariablesType & NonQueryInput
-  ): Promise<NFTTrendingCollectionFormattedResult> {
+    variables: NFTTrendingCollectionsInput
+  ): Promise<NFTTrendingCollectionResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -194,8 +199,8 @@ export class NftsController {
     const {
       data: { [userChain]: trendingCollections },
     } = await this.client.query<
-      NFTTrendingCollectionsQueryVariablesType, // What the user can pass in
-      NFTTrendingCollectionsQueryType, // The actual unmodified result from query
+      NFTTrendingCollectionsQueryVariables, // What the user can pass in
+      NFTTrendingCollectionsQuery, // The actual unmodified result from query
       NFTTrendingCollectionsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -208,7 +213,7 @@ export class NftsController {
 
     const formattedResult = formatQueryResult<
       NFTTrendingCollectionsQueryResultBody,
-      NFTTrendingCollectionFormattedResult
+      NFTTrendingCollectionResult
     >(
       trendingCollections,
       'trendingCollections',
@@ -220,8 +225,8 @@ export class NftsController {
   }
 
   async getByContractAddress(
-    variables: NFTsByContractAddressQueryVariablesType & NonQueryInput
-  ): Promise<NFTsByContractAddressFormattedResult> {
+    variables: NFTsByContractAddressInput
+  ): Promise<NFTsByContractAddressResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -235,8 +240,8 @@ export class NftsController {
         [userChain]: { collection },
       },
     } = await this.client.query<
-      NFTsByContractAddressQueryVariablesType, // What the user can pass in
-      NFTsByContractAddressQueryType, // The actual unmodified result from query
+      NFTsByContractAddressQueryVariables, // What the user can pass in
+      NFTsByContractAddressQuery, // The actual unmodified result from query
       NFTsByContractAddressQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -252,9 +257,7 @@ export class NftsController {
       };
     }
 
-    const setErcStandard = (
-      results: any
-    ): NFTsByContractAddressFormattedResult => {
+    const setErcStandard = (results: any): NFTsByContractAddressResult => {
       const standardMap: Record<string, NftErcStandards> = {
         ERC1155Collection: 'ERC1155',
         ERC721Collection: 'ERC721',
@@ -269,15 +272,13 @@ export class NftsController {
 
     const formattedResult = formatQueryResult<
       NFTsByContractAddressQueryResultInfo,
-      NFTsByContractAddressFormattedResult
+      NFTsByContractAddressResult
     >(collection, 'nfts', 'nftsPageInfo', null, setErcStandard);
 
     return formattedResult;
   }
 
-  async getNFTDetails(
-    variables: NFTDetailsQueryVariablesType & NonQueryInput
-  ): Promise<NFTDetailsFormattedResult> {
+  async getNFTDetails(variables: NFTDetailsInput): Promise<NFTDetailsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -291,8 +292,8 @@ export class NftsController {
         [userChain]: { nft },
       },
     } = await this.client.query<
-      NFTDetailsQueryVariablesType, // What the user can pass in
-      NFTDetailsQueryType, // The actual unmodified result from query
+      NFTDetailsQueryVariables, // What the user can pass in
+      NFTDetailsQuery, // The actual unmodified result from query
       NFTDetailsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query
@@ -304,8 +305,8 @@ export class NftsController {
   }
 
   async getCollectionDetails(
-    variables: NftCollectionDetailsQueryVariablesType & NonQueryInput
-  ): Promise<NftCollectionDetailsFormattedResult> {
+    variables: NftCollectionDetailsInput
+  ): Promise<NftCollectionDetailsResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -319,8 +320,8 @@ export class NftsController {
         [userChain]: { collection },
       },
     } = await this.client.query<
-      NftCollectionDetailsQueryVariablesType, // What the user can pass in
-      NftCollectionDetailsQueryType, // The actual unmodified result from query
+      NftCollectionDetailsQueryVariables, // What the user can pass in
+      NftCollectionDetailsQuery, // The actual unmodified result from query
       NftCollectionDetailsQueryResultFull // the modified result (edges and nodes removed)
     >({
       query: query[userChain], // The actual graphql query

--- a/packages/libs/sdk/src/api/controllers/tokens.ts
+++ b/packages/libs/sdk/src/api/controllers/tokens.ts
@@ -1,20 +1,21 @@
 import { CustomUrqlClient } from '../graphql/customUrqlClient';
 import { ChainName } from '../types/chains';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 import {
   BalancesByWalletENSQueryResultInfo,
-  BalancesByWalletENSFormattedResult,
+  BalancesByWalletENSResult,
   BalancesByWalletENSQueryResultFull,
-  BalancesByWalletENSQueryVariablesType,
-  BalancesByWalletENSQueryType,
+  BalancesByWalletENSQueryVariables,
+  BalancesByWalletENSQuery,
+  BalancesByWalletENSInput,
 } from '../types/tokens/getBalancesByWalletENS';
 import {
   BalancesByWalletAddressQueryResultInfo,
-  BalancesByWalletAddressFormattedResult,
+  BalancesByWalletAddressResult,
   BalancesByWalletAddressQueryResultFull,
-  BalancesByWalletAddressQueryVariablesType,
-  BalancesByWalletAddressQueryType,
+  BalancesByWalletAddressQueryVariables,
+  BalancesByWalletAddressQuery,
+  BalancesByWalletAddressInput,
 } from '../types/tokens/getBalancesByWalletAddress';
 import {
   CodegenEthMainnetBalancesByWalletENSDocument,
@@ -36,8 +37,8 @@ export class TokensController {
   ) {}
 
   async getBalancesByWallet(
-    variables: BalancesByWalletAddressQueryVariablesType & NonQueryInput
-  ): Promise<BalancesByWalletENSFormattedResult> {
+    variables: BalancesByWalletAddressInput
+  ): Promise<BalancesByWalletENSResult> {
     const { address, ...allVariables } = variables;
     if (isValidENSAddress(address)) {
       return this.getBalancesByWalletENS({
@@ -52,8 +53,8 @@ export class TokensController {
   }
 
   private async getBalancesByWalletENS(
-    variables: BalancesByWalletENSQueryVariablesType & NonQueryInput
-  ): Promise<BalancesByWalletENSFormattedResult> {
+    variables: BalancesByWalletENSInput
+  ): Promise<BalancesByWalletENSResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -67,8 +68,8 @@ export class TokensController {
         [userChain]: { walletByENS },
       },
     } = await this.client.query<
-      BalancesByWalletENSQueryVariablesType,
-      BalancesByWalletENSQueryType,
+      BalancesByWalletENSQueryVariables,
+      BalancesByWalletENSQuery,
       BalancesByWalletENSQueryResultFull
     >({
       variables: queryVariables,
@@ -89,7 +90,7 @@ export class TokensController {
 
     const formattedResult = formatQueryResult<
       BalancesByWalletENSQueryResultInfo,
-      BalancesByWalletENSFormattedResult
+      BalancesByWalletENSResult
     >(
       walletByENS,
       'tokenBalances',
@@ -102,8 +103,8 @@ export class TokensController {
   }
 
   private async getBalancesByWalletAddress(
-    variables: BalancesByWalletAddressQueryVariablesType & NonQueryInput
-  ): Promise<BalancesByWalletAddressFormattedResult> {
+    variables: BalancesByWalletAddressInput
+  ): Promise<BalancesByWalletAddressResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -117,8 +118,8 @@ export class TokensController {
         [userChain]: { walletByAddress },
       },
     } = await this.client.query<
-      BalancesByWalletAddressQueryVariablesType,
-      BalancesByWalletAddressQueryType,
+      BalancesByWalletAddressQueryVariables,
+      BalancesByWalletAddressQuery,
       BalancesByWalletAddressQueryResultFull
     >({
       variables: queryVariables,
@@ -139,7 +140,7 @@ export class TokensController {
 
     const formattedResult = formatQueryResult<
       BalancesByWalletAddressQueryResultInfo,
-      BalancesByWalletAddressFormattedResult
+      BalancesByWalletAddressResult
     >(
       walletByAddress,
       'tokenBalances',
@@ -151,9 +152,7 @@ export class TokensController {
     return formattedResult;
   }
 
-  private flattenBalanceResponses(
-    response: any
-  ): BalancesByWalletENSFormattedResult {
+  private flattenBalanceResponses(response: any): BalancesByWalletENSResult {
     const modifiedResults = response.results.map((result: any) => {
       const {
         contract: { ...contractInfo },

--- a/packages/libs/sdk/src/api/controllers/transactions.ts
+++ b/packages/libs/sdk/src/api/controllers/transactions.ts
@@ -1,33 +1,36 @@
 import { CustomUrqlClient } from '../graphql/customUrqlClient';
 import { ChainName } from '../types/chains';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 import {
   TransactionsByWalletAddressQueryResultInfo,
-  TransactionsByWalletAddressFormattedResult,
+  TransactionsByWalletAddressResult,
   TransactionsByWalletAddressQueryResultFull,
-  TransactionsByWalletAddressQueryVariablesType,
-  TransactionsByWalletAddressQueryType,
+  TransactionsByWalletAddressQueryVariables,
+  TransactionsByWalletAddressQuery,
+  TransactionsByWalletAddressInput,
 } from '../types/transactions/getByWalletAddress';
 import {
   TransactionsByWalletENSQueryResultInfo,
-  TransactionsByWalletENSFormattedResult,
+  TransactionsByWalletENSResult,
   TransactionsByWalletENSQueryResultFull,
-  TransactionsByWalletENSQueryVariablesType,
-  TransactionsByWalletENSQueryType,
+  TransactionsByWalletENSQueryVariables,
+  TransactionsByWalletENSQuery,
+  TransactionsByWalletENSInput,
 } from '../types/transactions/getByWalletENS';
 import {
   TransactionsBySearchQueryResultInfo,
-  TransactionsBySearchFormattedResult,
+  TransactionsBySearchResult,
   TransactionsBySearchQueryResultFull,
-  TransactionsBySearchQueryVariablesType,
-  TransactionsBySearchQueryType,
+  TransactionsBySearchQueryVariables,
+  TransactionsBySearchQuery,
+  TransactionsBySearchInput,
 } from '../types/transactions/getBySearch';
 import {
-  TransactionsByHashFormattedResult,
+  TransactionsByHashResult,
   TransactionsByHashQueryResultFull,
-  TransactionsByHashQueryVariablesType,
-  TransactionsByHashQueryType,
+  TransactionsByHashQueryVariables,
+  TransactionsByHashQuery,
+  TransactionsByHashInput,
 } from '../types/transactions/getByHash';
 import {
   CodegenEthMainnetTransactionsByWalletAddressDocument,
@@ -55,10 +58,9 @@ export class TransactionsController {
   ) {}
 
   async getByWallet(
-    variables: TransactionsByWalletAddressQueryVariablesType & NonQueryInput
+    variables: TransactionsByWalletAddressInput
   ): Promise<
-    | TransactionsByWalletAddressFormattedResult
-    | TransactionsByWalletENSFormattedResult
+    TransactionsByWalletAddressResult | TransactionsByWalletENSResult
   > {
     const { address, ...allVariables } = variables;
     let queryResult:
@@ -90,14 +92,14 @@ export class TransactionsController {
 
     const formattedResult = formatQueryResult<
       TransactionsByWalletAddressQueryResultInfo, // this is the same as TransactionsByWalletENSQueryResultInfo
-      TransactionsByWalletAddressFormattedResult // this is the same as TransactionsByWalletENSFormattedResult
+      TransactionsByWalletAddressResult // this is the same as TransactionsByWalletENSResult
     >(queryResult, 'transactions', 'transactionsPageInfo');
 
     return formattedResult;
   }
 
   private async getByWalletAddress(
-    variables: TransactionsByWalletAddressQueryVariablesType & NonQueryInput
+    variables: TransactionsByWalletAddressInput
   ): Promise<TransactionsByWalletAddressQueryResultInfo> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
@@ -111,8 +113,8 @@ export class TransactionsController {
         [userChain]: { walletByAddress },
       },
     } = await this.client.query<
-      TransactionsByWalletAddressQueryVariablesType,
-      TransactionsByWalletAddressQueryType,
+      TransactionsByWalletAddressQueryVariables,
+      TransactionsByWalletAddressQuery,
       TransactionsByWalletAddressQueryResultFull
     >({
       variables: queryVariables,
@@ -123,7 +125,7 @@ export class TransactionsController {
   }
 
   private async getByWalletENS(
-    variables: TransactionsByWalletENSQueryVariablesType & NonQueryInput
+    variables: TransactionsByWalletENSInput
   ): Promise<TransactionsByWalletENSQueryResultInfo> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
@@ -137,8 +139,8 @@ export class TransactionsController {
         [userChain]: { walletByENS },
       },
     } = await this.client.query<
-      TransactionsByWalletENSQueryVariablesType,
-      TransactionsByWalletENSQueryType,
+      TransactionsByWalletENSQueryVariables,
+      TransactionsByWalletENSQuery,
       TransactionsByWalletENSQueryResultFull
     >({
       variables: queryVariables,
@@ -149,8 +151,8 @@ export class TransactionsController {
   }
 
   async getAll(
-    variables: TransactionsBySearchQueryVariablesType & NonQueryInput
-  ): Promise<TransactionsBySearchFormattedResult> {
+    variables: TransactionsBySearchInput
+  ): Promise<TransactionsBySearchResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -161,8 +163,8 @@ export class TransactionsController {
     const {
       data: { [userChain]: transactions },
     } = await this.client.query<
-      TransactionsBySearchQueryVariablesType,
-      TransactionsBySearchQueryType,
+      TransactionsBySearchQueryVariables,
+      TransactionsBySearchQuery,
       TransactionsBySearchQueryResultFull
     >({
       variables: queryVariables,
@@ -171,15 +173,15 @@ export class TransactionsController {
 
     const formattedResult = formatQueryResult<
       TransactionsBySearchQueryResultInfo,
-      TransactionsBySearchFormattedResult
+      TransactionsBySearchResult
     >(transactions, 'transactions', 'transactionsPageInfo');
 
     return formattedResult;
   }
 
   async getByHash(
-    variables: TransactionsByHashQueryVariablesType & NonQueryInput
-  ): Promise<TransactionsByHashFormattedResult> {
+    variables: TransactionsByHashInput
+  ): Promise<TransactionsByHashResult> {
     const { chain, ...queryVariables } = variables;
     const userChain = chain || this.defaultChain;
     const query: Record<ChainName, TypedDocumentNode<any, any>> = {
@@ -191,8 +193,8 @@ export class TransactionsController {
     const {
       data: { [userChain]: transaction },
     } = await this.client.query<
-      TransactionsByHashQueryVariablesType,
-      TransactionsByHashQueryType,
+      TransactionsByHashQueryVariables,
+      TransactionsByHashQuery,
       TransactionsByHashQueryResultFull
     >({
       variables: queryVariables,

--- a/packages/libs/sdk/src/api/controllers/utils.ts
+++ b/packages/libs/sdk/src/api/controllers/utils.ts
@@ -1,12 +1,12 @@
 import { CustomUrqlClient } from '../graphql/customUrqlClient';
 import { ChainName } from '../types/chains';
 import { DEFAULT_CHAIN } from '../utils/constants';
-import { NonQueryInput } from '../types/input';
 import {
-  GasPricesFormattedResult,
+  GasPricesResult,
   GasPricesQueryResultFull,
-  GasPricesQueryVariablesType,
-  GasPricesQueryType,
+  GasPricesQueryVariables,
+  GasPricesQuery,
+  GasPricesInput,
 } from '../types/utils/gasPrices';
 import {
   CodegenEthMainnetGasPricesDocument,
@@ -22,9 +22,7 @@ export class UtilsController {
     private defaultChain: ChainName = DEFAULT_CHAIN
   ) {}
 
-  async getGasPrices(
-    variables: GasPricesQueryVariablesType & NonQueryInput
-  ): Promise<GasPricesFormattedResult> {
+  async getGasPrices(variables: GasPricesInput): Promise<GasPricesResult> {
     const { chain, ...queryVariables } = variables;
     const returnInGwei = variables.returnInGwei || false;
     const userChain = chain || this.defaultChain;
@@ -39,8 +37,8 @@ export class UtilsController {
         [userChain]: { gasPrices },
       },
     } = await this.client.query<
-      GasPricesQueryVariablesType,
-      GasPricesQueryType,
+      GasPricesQueryVariables,
+      GasPricesQuery,
       GasPricesQueryResultFull
     >({
       query: query[userChain],

--- a/packages/libs/sdk/src/api/types/contracts/getContractDetails.ts
+++ b/packages/libs/sdk/src/api/types/contracts/getContractDetails.ts
@@ -4,13 +4,17 @@ import {
   CodegenContractInfoFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type ContractDetailsQueryType = {
+export type ContractDetailsQuery = {
   [k in ChainName]: CodegenEthMainnetContractDetailsQuery['ethereum'];
 };
 
-export type ContractDetailsQueryVariablesType =
+export type ContractDetailsQueryVariables =
   CodegenEthMainnetContractDetailsQueryVariables;
+
+export type ContractDetailsInput = ContractDetailsQueryVariables &
+  NonQueryInput;
 
 export interface ContractDetailsQueryResultInfo {
   contract: CodegenContractInfoFragment;
@@ -21,6 +25,6 @@ export type ContractDetailsQueryResultFull = Record<
   ContractDetailsQueryResultInfo
 >;
 
-export type ContractDetailsFormattedResult = {
+export type ContractDetailsResult = {
   contract: CodegenContractInfoFragment | null;
 };

--- a/packages/libs/sdk/src/api/types/events/getAll.ts
+++ b/packages/libs/sdk/src/api/types/events/getAll.ts
@@ -5,13 +5,16 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type AllEventsQueryType = {
+export type AllEventsQuery = {
   [k in ChainName]: CodegenEthereumMainnetEventsGetAllQuery['ethereum'];
 };
 
-export type AllEventsQueryVariablesType =
+export type AllEventsQueryVariables =
   CodegenEthereumMainnetEventsGetAllQueryVariables;
+
+export type AllEventsInput = AllEventsQueryVariables & NonQueryInput;
 
 export interface AllEventsQueryResultInfo {
   tokenEvents: CodegenTokenEventInfoFragment[];
@@ -27,7 +30,7 @@ export type AllEventsQueryResultFull = Record<
   AllEventsQueryResultBody
 >;
 
-export type AllEventsFormattedResult = {
+export type AllEventsResult = {
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/events/getByContract.ts
+++ b/packages/libs/sdk/src/api/types/events/getByContract.ts
@@ -5,13 +5,16 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type ContractEventsQueryType = {
+export type ContractEventsQuery = {
   [k in ChainName]: CodegenEthereumMainnetEventsByContractQuery['ethereum'];
 };
 
-export type ContractEventsQueryVariablesType =
+export type ContractEventsQueryVariables =
   CodegenEthereumMainnetEventsByContractQueryVariables;
+
+export type ContractEventsInput = ContractEventsQueryVariables & NonQueryInput;
 
 export interface ContractEventsQueryResultInfo {
   tokenEvents: CodegenTokenEventInfoFragment[];
@@ -27,7 +30,7 @@ export type ContractEventsQueryResultFull = Record<
   ContractEventsQueryResultBody
 >;
 
-export type ContractEventsFormattedResult = {
+export type ContractEventsResult = {
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/index.ts
+++ b/packages/libs/sdk/src/api/types/index.ts
@@ -1,0 +1,60 @@
+export {
+  ContractDetailsInput,
+  ContractDetailsResult,
+} from './contracts/getContractDetails';
+export { AllEventsInput, AllEventsResult } from './events/getAll';
+export {
+  ContractEventsInput,
+  ContractEventsResult,
+} from './events/getByContract';
+export {
+  NFTsByContractAddressInput,
+  NFTsByContractAddressResult,
+} from './nfts/getByContractAddress';
+export {
+  WalletNFTsByAddressInput,
+  WalletNFTsByAddressResult,
+} from './nfts/getByWalletAddress';
+export {
+  WalletNFTsByEnsInput,
+  WalletNFTsByEnsResult,
+} from './nfts/getByWalletENS';
+export {
+  NftCollectionDetailsInput,
+  NftCollectionDetailsResult,
+} from './nfts/getCollectionDetails';
+export {
+  CollectionEventsInput,
+  CollectionEventsResult,
+} from './nfts/getCollectionEvents';
+export { NFTDetailsInput, NFTDetailsResult } from './nfts/getNFTDetails';
+export { NFTEventsInput, NFTEventsResult } from './nfts/getNFTEvents';
+export {
+  NFTTrendingCollectionsInput,
+  NFTTrendingCollectionResult,
+} from './nfts/getTrendingCollections';
+export {
+  BalancesByWalletAddressInput,
+  BalancesByWalletAddressResult,
+} from './tokens/getBalancesByWalletAddress';
+export {
+  BalancesByWalletENSInput,
+  BalancesByWalletENSResult,
+} from './tokens/getBalancesByWalletENS';
+export {
+  TransactionsByHashInput,
+  TransactionsByHashResult,
+} from './transactions/getByHash';
+export {
+  TransactionsBySearchInput,
+  TransactionsBySearchResult,
+} from './transactions/getBySearch';
+export {
+  TransactionsByWalletAddressInput,
+  TransactionsByWalletAddressResult,
+} from './transactions/getByWalletAddress';
+export {
+  TransactionsByWalletENSInput,
+  TransactionsByWalletENSResult,
+} from './transactions/getByWalletENS';
+export { GasPricesInput, GasPricesResult } from './utils/gasPrices';

--- a/packages/libs/sdk/src/api/types/nfts/getByContractAddress.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByContractAddress.ts
@@ -6,14 +6,18 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 import { NftErcStandards } from '../nfts';
 
-export type NFTsByContractAddressQueryType = {
+export type NFTsByContractAddressQuery = {
   [k in ChainName]: CodegenEthMainnetWalletNFTsByContractAddressQuery['ethereum'];
 };
 
-export type NFTsByContractAddressQueryVariablesType =
+export type NFTsByContractAddressQueryVariables =
   CodegenEthMainnetWalletNFTsByContractAddressQueryVariables;
+
+export type NFTsByContractAddressInput = NFTsByContractAddressQueryVariables &
+  NonQueryInput;
 
 export interface NFTsByContractAddressQueryResultInfo {
   __typename: string;
@@ -30,7 +34,7 @@ export type NFTsByContractAddressQueryResultFull = Record<
   NFTsByContractAddressQueryResultBody
 >;
 
-export type NFTsByContractAddressFormattedResult = {
+export type NFTsByContractAddressResult = {
   standard: NftErcStandards | null;
   results: [CodegenERC721NFTNodeFragment | CodegenERC1155NFTNodeFragment][];
   pageInfo: CodegenPaginationFragment;

--- a/packages/libs/sdk/src/api/types/nfts/getByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByWalletAddress.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetWalletNFTsByAddressQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type WalletNFTsByAddressQueryType = {
+export type WalletNFTsByAddressQuery = {
   [k in ChainName]: CodegenEthMainnetWalletNFTsByAddressQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetWalletNFTsByAddressQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type WalletNFTsByAddressQueryVariablesType =
+export type WalletNFTsByAddressQueryVariables =
   CodegenEthMainnetWalletNFTsByAddressQueryVariables;
+
+export type WalletNFTsByAddressInput = WalletNFTsByAddressQueryVariables &
+  NonQueryInput;
 
 export interface WalletNFTsByAddressQueryResultInfo {
   address: string;
@@ -34,7 +38,7 @@ export type WalletNFTByAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type WalletNFTsByAddressFormattedResult = {
+export type WalletNFTsByAddressResult = {
   address: string;
   ensName: string;
   results: CodegenWalletNFTNodeFragment['nft'][];

--- a/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
@@ -18,7 +18,7 @@ export type WalletNFTsByEnsQuery = {
 export type WalletNFTsByEnsQueryVariables =
   CodegenEthMainnetWalletNFTsByEnsQueryVariables;
 
-export type WalletNFTsByENSInput = WalletNFTsByEnsQueryVariables &
+export type WalletNFTsByEnsInput = WalletNFTsByEnsQueryVariables &
   NonQueryInput;
 
 export interface WalletNFTsByEnsQueryResultInfo {

--- a/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetWalletNFTsByEnsQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type WalletNFTsByEnsQueryType = {
+export type WalletNFTsByEnsQuery = {
   [k in ChainName]: CodegenEthMainnetWalletNFTsByEnsQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetWalletNFTsByEnsQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type WalletNFTsByEnsQueryVariablesType =
+export type WalletNFTsByEnsQueryVariables =
   CodegenEthMainnetWalletNFTsByEnsQueryVariables;
+
+export type WalletNFTsByENSInput = WalletNFTsByEnsQueryVariables &
+  NonQueryInput;
 
 export interface WalletNFTsByEnsQueryResultInfo {
   address: string;
@@ -34,7 +38,7 @@ export type WalletNFTsByEnsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type WalletNFTsByEnsFormattedResult = {
+export type WalletNFTsByEnsResult = {
   address: string;
   ensName: string;
   results: CodegenWalletNFTNodeFragment['nft'][];

--- a/packages/libs/sdk/src/api/types/nfts/getCollectionDetails.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getCollectionDetails.ts
@@ -4,13 +4,17 @@ import {
   CodegenNftCollectionInfoFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type NftCollectionDetailsQueryType = {
+export type NftCollectionDetailsQuery = {
   [k in ChainName]: CodegenEthMainnetNftCollectionDetailsQuery['ethereum'];
 };
 
-export type NftCollectionDetailsQueryVariablesType =
+export type NftCollectionDetailsQueryVariables =
   CodegenEthMainnetNftCollectionDetailsQueryVariables;
+
+export type NftCollectionDetailsInput = NftCollectionDetailsQueryVariables &
+  NonQueryInput;
 
 export interface NftCollectionDetailsQueryResultInfo {
   collection: CodegenNftCollectionInfoFragment['collection'];
@@ -23,6 +27,6 @@ export type NftCollectionDetailsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type NftCollectionDetailsFormattedResult = {
+export type NftCollectionDetailsResult = {
   collection: CodegenNftCollectionInfoFragment['collection'];
 };

--- a/packages/libs/sdk/src/api/types/nfts/getCollectionEvents.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getCollectionEvents.ts
@@ -5,13 +5,17 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type CollectionEventsQueryType = {
+export type CollectionEventsQuery = {
   [k in ChainName]: CodegenEthMainnetEventsByCollectionQuery['ethereum'];
 };
 
-export type CollectionEventsQueryVariablesType =
+export type CollectionEventsQueryVariables =
   CodegenEthMainnetEventsByCollectionQueryVariables;
+
+export type CollectionEventsInput = CollectionEventsQueryVariables &
+  NonQueryInput;
 
 export interface CollectionEventsQueryResultInfo {
   tokenEvents: CodegenTokenEventInfoFragment[];
@@ -27,7 +31,7 @@ export type CollectionEventsQueryResultFull = Record<
   CollectionEventsQueryResultBody
 >;
 
-export type CollectionEventsFormattedResult = {
+export type CollectionEventsResult = {
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/nfts/getNFTDetails.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getNFTDetails.ts
@@ -4,13 +4,16 @@ import {
   CodegenNftDetailsFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type NFTDetailsQueryType = {
+export type NFTDetailsQuery = {
   [k in ChainName]: CodegenEthMainnetNFTDetailsQuery['ethereum'];
 };
 
-export type NFTDetailsQueryVariablesType =
+export type NFTDetailsQueryVariables =
   CodegenEthMainnetNFTDetailsQueryVariables;
+
+export type NFTDetailsInput = NFTDetailsQueryVariables & NonQueryInput;
 
 export interface NFTDetailsQueryResultInfo {
   nft: CodegenNftDetailsFragment['nft'];
@@ -22,6 +25,6 @@ export type NFTDetailsQueryResultFull = Record<
   NFTDetailsQueryResultInfo
 >;
 
-export type NFTDetailsFormattedResult = {
+export type NFTDetailsResult = {
   nft: CodegenNftDetailsFragment['nft'];
 };

--- a/packages/libs/sdk/src/api/types/nfts/getNFTEvents.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getNFTEvents.ts
@@ -5,13 +5,16 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type NFTEventsQueryType = {
+export type NFTEventsQuery = {
   [k in ChainName]: CodegenEthereumMainnetEventsByNftQuery['ethereum'];
 };
 
-export type NFTEventsQueryVariablesType =
+export type NFTEventsQueryVariables =
   CodegenEthereumMainnetEventsByNftQueryVariables;
+
+export type NFTEventsInput = NFTEventsQueryVariables & NonQueryInput;
 
 export interface NFTEventsQueryResultInfo {
   tokenEvents: CodegenTokenEventInfoFragment[];
@@ -27,7 +30,7 @@ export type NFTEventsQueryResultFull = Record<
   NFTEventsQueryResultBody
 >;
 
-export type NFTEventsFormattedResult = {
+export type NFTEventsResult = {
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/nfts/getTrendingCollections.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getTrendingCollections.ts
@@ -5,13 +5,17 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type NFTTrendingCollectionsQueryType = {
+export type NFTTrendingCollectionsQuery = {
   [k in ChainName]: CodegenEthMainnetTrendingCollectionsQuery['ethereum'];
 };
 
-export type NFTTrendingCollectionsQueryVariablesType =
+export type NFTTrendingCollectionsQueryVariables =
   CodegenEthMainnetTrendingCollectionsQueryVariables;
+
+export type NFTTrendingCollectionsInput = NFTTrendingCollectionsQueryVariables &
+  NonQueryInput;
 
 export interface NFTTrendingCollectionsQueryResultBody {
   trendingCollectionsPageInfo: CodegenPaginationFragment;
@@ -25,7 +29,7 @@ export type NFTTrendingCollectionsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type NFTTrendingCollectionFormattedResult = {
+export type NFTTrendingCollectionResult = {
   results: CodegenTrendingCollectionInfoFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletAddress.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetBalancesByWalletAddressQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type BalancesByWalletAddressQueryType = {
+export type BalancesByWalletAddressQuery = {
   [k in ChainName]: CodegenEthMainnetBalancesByWalletAddressQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetBalancesByWalletAddressQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type BalancesByWalletAddressQueryVariablesType =
+export type BalancesByWalletAddressQueryVariables =
   CodegenEthMainnetBalancesByWalletAddressQueryVariables;
+
+export type BalancesByWalletAddressInput =
+  BalancesByWalletAddressQueryVariables & NonQueryInput;
 
 export interface BalancesByWalletAddressQueryResultInfo {
   address: string;
@@ -35,7 +39,7 @@ export type BalancesByWalletAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type BalancesByWalletAddressFormattedResult = {
+export type BalancesByWalletAddressResult = {
   address: string;
   ensName: string;
   results: CodegenTokenBalanceNodeFragment[];

--- a/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletENS.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetBalancesByWalletENSQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type BalancesByWalletENSQueryType = {
+export type BalancesByWalletENSQuery = {
   [k in ChainName]: CodegenEthMainnetBalancesByWalletENSQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetBalancesByWalletENSQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type BalancesByWalletENSQueryVariablesType =
+export type BalancesByWalletENSQueryVariables =
   CodegenEthMainnetBalancesByWalletENSQueryVariables;
+
+export type BalancesByWalletENSInput =
+  CodegenEthMainnetBalancesByWalletENSQueryVariables & NonQueryInput;
 
 export interface BalancesByWalletENSQueryResultInfo {
   address: string;
@@ -35,7 +39,7 @@ export type BalancesByWalletENSQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type BalancesByWalletENSFormattedResult = {
+export type BalancesByWalletENSResult = {
   address: string;
   ensName: string;
   results: CodegenTokenBalanceNodeFragment[];

--- a/packages/libs/sdk/src/api/types/transactions/getByHash.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByHash.ts
@@ -4,17 +4,21 @@ import {
   CodegenTransactionsNodeFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetTransactionsByHashQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type TransactionsByHashQueryType = {
+export type TransactionsByHashQuery = {
   [k in ChainName]: CodegenEthMainnetTransactionsByHashQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetTransactionsByHashQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type TransactionsByHashQueryVariablesType =
+export type TransactionsByHashQueryVariables =
   CodegenEthMainnetTransactionsByHashQueryVariables;
+
+export type TransactionsByHashInput = TransactionsByHashQueryVariables &
+  NonQueryInput;
 
 export interface TransactionsByHashQueryResultBody {
   transaction: CodegenTransactionsNodeFragment;
@@ -25,6 +29,6 @@ export type TransactionsByHashQueryResultFull = Record<
   TransactionsByHashQueryResultBody
 >;
 
-export type TransactionsByHashFormattedResult = {
+export type TransactionsByHashResult = {
   transaction: CodegenTransactionsNodeFragment | null;
 };

--- a/packages/libs/sdk/src/api/types/transactions/getBySearch.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getBySearch.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetTransactionsBySearchQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type TransactionsBySearchQueryType = {
+export type TransactionsBySearchQuery = {
   [k in ChainName]: CodegenEthMainnetTransactionsBySearchQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetTransactionsBySearchQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type TransactionsBySearchQueryVariablesType =
+export type TransactionsBySearchQueryVariables =
   CodegenEthMainnetTransactionsBySearchQueryVariables;
+
+export type TransactionsBySearchInput = TransactionsBySearchQueryVariables &
+  NonQueryInput;
 
 export interface TransactionsBySearchQueryResultInfo {
   transactionsPageInfo: CodegenPaginationFragment;
@@ -33,7 +37,7 @@ export type TransactionsBySearchQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsBySearchFormattedResult = {
+export type TransactionsBySearchResult = {
   results: CodegenTransactionsNodeFragment[];
   pageInfo: CodegenPaginationFragment;
 };

--- a/packages/libs/sdk/src/api/types/transactions/getByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByWalletAddress.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetTransactionsByWalletAddressQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type TransactionsByWalletAddressQueryType = {
+export type TransactionsByWalletAddressQuery = {
   [k in ChainName]: CodegenEthMainnetTransactionsByWalletAddressQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetTransactionsByWalletAddressQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type TransactionsByWalletAddressQueryVariablesType =
+export type TransactionsByWalletAddressQueryVariables =
   CodegenEthMainnetTransactionsByWalletAddressQueryVariables;
+
+export type TransactionsByWalletAddressInput =
+  TransactionsByWalletAddressQueryVariables & NonQueryInput;
 
 export interface TransactionsByWalletAddressQueryResultInfo {
   address: string;
@@ -35,7 +39,7 @@ export type TransactionsByWalletAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsByWalletAddressFormattedResult = {
+export type TransactionsByWalletAddressResult = {
   address: string;
   ensName: string;
   results: CodegenTransactionsNodeFragment[];

--- a/packages/libs/sdk/src/api/types/transactions/getByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByWalletENS.ts
@@ -5,17 +5,21 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetTransactionsByWalletENSQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
-export type TransactionsByWalletENSQueryType = {
+export type TransactionsByWalletENSQuery = {
   [k in ChainName]: CodegenEthMainnetTransactionsByWalletENSQuery['ethereum'];
 };
 
 // Using the generated CodegenEthMainnetTransactionsByWalletENSQueryVariables as a base for the type here
 // since the variables will be the same for each query
-export type TransactionsByWalletENSQueryVariablesType =
+export type TransactionsByWalletENSQueryVariables =
   CodegenEthMainnetTransactionsByWalletENSQueryVariables;
+
+export type TransactionsByWalletENSInput =
+  TransactionsByWalletENSQueryVariables & NonQueryInput;
 
 export interface TransactionsByWalletENSQueryResultInfo {
   address: string;
@@ -35,7 +39,7 @@ export type TransactionsByWalletENSQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsByWalletENSFormattedResult = {
+export type TransactionsByWalletENSResult = {
   address: string;
   ensName: string;
   results: CodegenTransactionsNodeFragment[];

--- a/packages/libs/sdk/src/api/types/utils/gasPrices.ts
+++ b/packages/libs/sdk/src/api/types/utils/gasPrices.ts
@@ -4,14 +4,16 @@ import {
   CodegenGasPrice,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { NonQueryInput } from '../input';
 
-export type GasPricesQueryType = {
+export type GasPricesQuery = {
   [k in ChainName]: CodegenEthMainnetGasPricesQuery['ethereum'];
 };
 
-export type GasPricesQueryVariablesType =
+export type GasPricesQueryVariables =
   CodegenEthMainnetGasPricesQueryVariables & { returnInGwei?: boolean };
 
+export type GasPricesInput = GasPricesQueryVariables & NonQueryInput;
 export interface GasPricesQueryResultInfo {
   gasPrices: CodegenGasPrice[];
 }
@@ -21,6 +23,6 @@ export type GasPricesQueryResultFull = Record<
   GasPricesQueryResultInfo
 >;
 
-export type GasPricesFormattedResult = {
+export type GasPricesResult = {
   gasPrices: CodegenGasPrice[];
 };

--- a/packages/libs/sdk/src/index.ts
+++ b/packages/libs/sdk/src/index.ts
@@ -1,5 +1,7 @@
 import QuickNode from './client';
 export { API } from './api';
+export * from './api/types';
+
 // re-export from libraries for convenience
 export { gql } from '@urql/core';
 


### PR DESCRIPTION
This allows users to import the types to use as needed. I also renamed a lot of the types so the names are a bit simpler

i.e.
```typescript
import QuickNode, { WalletNFTsByAddressInput } from "@quicknode/sdk";
const qn = new QuickNode.API({});
const input: WalletNFTsByAddressInput = {
  address: "quicknode.eth",
  first: 2,
};
let response = await qn.nfts.getByWallet(input);
```
