### PR TITLE
Add headers to monitor SDK usage

### DIFF
--- a/packages/libs/sdk/spec/testSetup/pollyTestSetup.ts
+++ b/packages/libs/sdk/spec/testSetup/pollyTestSetup.ts
@@ -36,7 +36,13 @@ export default async function withPolly(
     logging: false,
     matchRequestsBy: {
       headers: {
-        exclude: ['X-API-KEY', 'x-api-key', 'content-length'],
+        exclude: [
+          'X-API-KEY',
+          'x-api-key',
+          'x-quicknode-sdk',
+          'x-quicknode-sdk-version',
+          'content-length',
+        ],
       },
       order: false,
       // @ts-ignore

--- a/packages/libs/sdk/src/api/api.ts
+++ b/packages/libs/sdk/src/api/api.ts
@@ -14,6 +14,7 @@ import { ChainName } from './types/chains';
 import { DEFAULT_CHAIN } from './utils/constants';
 import schema from './graphql/schema.json';
 import { TransactionsController } from './controllers/transactions';
+import packageJson from '../../package.json';
 
 export interface ApiArguments {
   graphApiKey?: string;
@@ -76,6 +77,8 @@ export class API {
   private createUrqlClient(): Client {
     const headers = { ...this.additionalHeaders };
     if (this.graphApiKey) headers['x-api-key'] = this.graphApiKey;
+    headers['x-qn-sdk'] = 'js';
+    headers['x-qn-sdk-version'] = packageJson?.version || 'n/a';
     const useNftKey = (data: Data) =>
       `${data['contractAddress']}:${data['tokenId']}`;
     const useAddressAsKey = (data: Data) => `${data['address']}`;

--- a/packages/libs/sdk/src/api/api.ts
+++ b/packages/libs/sdk/src/api/api.ts
@@ -77,7 +77,7 @@ export class API {
   private createUrqlClient(): Client {
     const headers = { ...this.additionalHeaders };
     if (this.graphApiKey) headers['x-api-key'] = this.graphApiKey;
-    headers['x-quicknode-sdk'] = 'js';
+    headers['x-quicknode-sdk'] = 'js-sdk';
     headers['x-quicknode-sdk-version'] = packageJson?.version || 'n/a';
     const useNftKey = (data: Data) =>
       `${data['contractAddress']}:${data['tokenId']}`;

--- a/packages/libs/sdk/src/api/api.ts
+++ b/packages/libs/sdk/src/api/api.ts
@@ -77,8 +77,8 @@ export class API {
   private createUrqlClient(): Client {
     const headers = { ...this.additionalHeaders };
     if (this.graphApiKey) headers['x-api-key'] = this.graphApiKey;
-    headers['x-qn-sdk'] = 'js';
-    headers['x-qn-sdk-version'] = packageJson?.version || 'n/a';
+    headers['x-quicknode-sdk'] = 'js';
+    headers['x-quicknode-sdk-version'] = packageJson?.version || 'n/a';
     const useNftKey = (data: Data) =>
       `${data['contractAddress']}:${data['tokenId']}`;
     const useAddressAsKey = (data: Data) => `${data['address']}`;

--- a/packages/libs/sdk/tsconfig.lib.json
+++ b/packages/libs/sdk/tsconfig.lib.json
@@ -6,15 +6,14 @@
     "target": "ES2020",
     "module": "ES2020",
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
-  "include": ["**/*.ts"],
+  "include": ["package.json", "src/**/*.ts"],
   "exclude": [
     "jest.config.ts",
     "**/*.spec.ts",
     "**/*.test.ts",
     "webpack.config.ts",
-    "src/spec/testSetup/**.*",
     "codegen.ts",
     "spec"
   ]


### PR DESCRIPTION
This imports the `package.json` file to determine the version. This does add around 1kb to the build because you have to pull in the whole package.json file, but I think that is fine right now.

There is [another approach](https://stackoverflow.com/a/67701490) that builds a custom file with the version at build time, which doesn't have to pull in the whole package.json - but I'm a little wary modifying source code at build time, and it's a pain to manage with git since even if you put a placeholder file there for development, it's overwritten every time the package is built locally.