### PR TITLE
Simplify return types

### DIFF
--- a/packages/libs/sdk/src/api/types/contracts/getContractDetails.ts
+++ b/packages/libs/sdk/src/api/types/contracts/getContractDetails.ts
@@ -8,6 +8,7 @@ import {
   isEvmAddress,
   supportedChainInput,
 } from '../../../lib/validation/validators';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type ContractDetailsQuery = {
@@ -37,6 +38,6 @@ export type ContractDetailsQueryResultFull = Record<
   ContractDetailsQueryResultInfo
 >;
 
-export type ContractDetailsResult = {
+export type ContractDetailsResult = SimplifyType<{
   contract: CodegenContractInfoFragment | null;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/events/getAll.ts
+++ b/packages/libs/sdk/src/api/types/events/getAll.ts
@@ -9,6 +9,7 @@ import {
   baseEventsInput,
   supportedChainInput,
 } from '../../../lib/validation/validators';
+import { SimplifyType } from '../../utils/helpers';
 
 import { z } from 'zod';
 
@@ -39,7 +40,7 @@ export type AllEventsQueryResultFull = Record<
   AllEventsQueryResultBody
 >;
 
-export type AllEventsResult = {
+export type AllEventsResult = SimplifyType<{
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/events/getByContract.ts
+++ b/packages/libs/sdk/src/api/types/events/getByContract.ts
@@ -10,6 +10,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type ContractEventsQuery = {
@@ -43,7 +44,7 @@ export type ContractEventsQueryResultFull = Record<
   ContractEventsQueryResultBody
 >;
 
-export type ContractEventsResult = {
+export type ContractEventsResult = SimplifyType<{
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getByContractAddress.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByContractAddress.ts
@@ -12,6 +12,7 @@ import {
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
 import { NftErcStandards } from '../nfts';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type NFTsByContractAddressQuery = {
@@ -45,8 +46,8 @@ export type NFTsByContractAddressQueryResultFull = Record<
   NFTsByContractAddressQueryResultBody
 >;
 
-export type NFTsByContractAddressResult = {
+export type NFTsByContractAddressResult = SimplifyType<{
   standard: NftErcStandards | null;
   results: [CodegenERC721NFTNodeFragment | CodegenERC1155NFTNodeFragment][];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByWalletAddress.ts
@@ -12,6 +12,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 // Using the generated CodegenEthMainnetWalletNFTsByAddressQuery as a base for the type here
@@ -58,9 +59,9 @@ export type WalletNFTByAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type WalletNFTsByAddressResult = {
+export type WalletNFTsByAddressResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenWalletNFTNodeFragment['nft'][];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getByWalletENS.ts
@@ -6,6 +6,7 @@ import {
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
 import { NonQueryInput } from '../input';
+import { SimplifyType } from '../../utils/helpers';
 
 // Using the generated CodegenEthMainnetWalletNFTsByEnsQuery as a base for the type here
 // since the queries for each chain will be the same, so allow for it to be used for all chains
@@ -38,9 +39,9 @@ export type WalletNFTsByEnsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type WalletNFTsByEnsResult = {
+export type WalletNFTsByEnsResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenWalletNFTNodeFragment['nft'][];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getCollectionDetails.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getCollectionDetails.ts
@@ -8,6 +8,7 @@ import {
   CodegenNftCollectionInfoFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type NftCollectionDetailsQuery = {
@@ -38,6 +39,6 @@ export type NftCollectionDetailsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type NftCollectionDetailsResult = {
+export type NftCollectionDetailsResult = SimplifyType<{
   collection: CodegenNftCollectionInfoFragment['collection'];
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getCollectionEvents.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getCollectionEvents.ts
@@ -10,6 +10,7 @@ import {
   isEvmAddress,
   supportedChainInput,
 } from '../../../lib/validation/validators';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type CollectionEventsQuery = {
@@ -42,7 +43,7 @@ export type CollectionEventsQueryResultFull = Record<
   CollectionEventsQueryResultBody
 >;
 
-export type CollectionEventsResult = {
+export type CollectionEventsResult = SimplifyType<{
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getNFTDetails.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getNFTDetails.ts
@@ -8,6 +8,7 @@ import {
   CodegenNftDetailsFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type NFTDetailsQuery = {
@@ -34,6 +35,6 @@ export type NFTDetailsQueryResultFull = Record<
   NFTDetailsQueryResultInfo
 >;
 
-export type NFTDetailsResult = {
+export type NFTDetailsResult = SimplifyType<{
   nft: CodegenNftDetailsFragment['nft'];
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getNFTEvents.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getNFTEvents.ts
@@ -10,6 +10,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type NFTEventsQuery = {
@@ -44,7 +45,7 @@ export type NFTEventsQueryResultFull = Record<
   NFTEventsQueryResultBody
 >;
 
-export type NFTEventsResult = {
+export type NFTEventsResult = SimplifyType<{
   results: CodegenTokenEventInfoFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/nfts/getTrendingCollections.ts
+++ b/packages/libs/sdk/src/api/types/nfts/getTrendingCollections.ts
@@ -9,6 +9,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type NFTTrendingCollectionsQuery = {
@@ -37,7 +38,7 @@ export type NFTTrendingCollectionsQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type NFTTrendingCollectionResult = {
+export type NFTTrendingCollectionResult = SimplifyType<{
   results: CodegenTrendingCollectionInfoFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletAddress.ts
@@ -11,6 +11,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 // Using the generated CodegenEthMainnetBalancesByWalletAddressQuery as a base for the type here
@@ -54,9 +55,9 @@ export type BalancesByWalletAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type BalancesByWalletAddressResult = {
+export type BalancesByWalletAddressResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenTokenBalanceNodeFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/tokens/getBalancesByWalletENS.ts
@@ -5,6 +5,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetBalancesByWalletENSQuery as a base for the type here
@@ -39,9 +40,9 @@ export type BalancesByWalletENSQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type BalancesByWalletENSResult = {
+export type BalancesByWalletENSResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenTokenBalanceNodeFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/transactions/getByHash.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByHash.ts
@@ -8,6 +8,7 @@ import {
   CodegenTransactionsNodeFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 // Using the generated CodegenEthMainnetTransactionsByHashQuery as a base for the type here
@@ -40,6 +41,6 @@ export type TransactionsByHashQueryResultFull = Record<
   TransactionsByHashQueryResultBody
 >;
 
-export type TransactionsByHashResult = {
+export type TransactionsByHashResult = SimplifyType<{
   transaction: CodegenTransactionsNodeFragment | null;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/transactions/getBySearch.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getBySearch.ts
@@ -9,6 +9,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 // Using the generated CodegenEthMainnetTransactionsBySearchQuery as a base for the type here
@@ -46,7 +47,7 @@ export type TransactionsBySearchQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsBySearchResult = {
+export type TransactionsBySearchResult = SimplifyType<{
   results: CodegenTransactionsNodeFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/transactions/getByWalletAddress.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByWalletAddress.ts
@@ -11,6 +11,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 // Using the generated CodegenEthMainnetTransactionsByWalletAddressQuery as a base for the type here
@@ -54,9 +55,9 @@ export type TransactionsByWalletAddressQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsByWalletAddressResult = {
+export type TransactionsByWalletAddressResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenTransactionsNodeFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/transactions/getByWalletENS.ts
+++ b/packages/libs/sdk/src/api/types/transactions/getByWalletENS.ts
@@ -5,6 +5,7 @@ import {
   CodegenPaginationFragment,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { NonQueryInput } from '../input';
 
 // Using the generated CodegenEthMainnetTransactionsByWalletENSQuery as a base for the type here
@@ -39,9 +40,9 @@ export type TransactionsByWalletENSQueryResultFull = Record<
 >;
 
 // What we actually return to the user
-export type TransactionsByWalletENSResult = {
+export type TransactionsByWalletENSResult = SimplifyType<{
   address: string;
   ensName: string;
   results: CodegenTransactionsNodeFragment[];
   pageInfo: CodegenPaginationFragment;
-};
+}>;

--- a/packages/libs/sdk/src/api/types/utils/gasPrices.ts
+++ b/packages/libs/sdk/src/api/types/utils/gasPrices.ts
@@ -8,6 +8,7 @@ import {
   CodegenGasPrice,
 } from '../../graphql/generatedTypes';
 import { ChainName } from '../chains';
+import { SimplifyType } from '../../utils/helpers';
 import { z } from 'zod';
 
 export type GasPricesQuery = {
@@ -35,6 +36,6 @@ export type GasPricesQueryResultFull = Record<
   GasPricesQueryResultInfo
 >;
 
-export type GasPricesResult = {
+export type GasPricesResult = SimplifyType<{
   gasPrices: CodegenGasPrice[];
-};
+}>;

--- a/packages/libs/sdk/src/api/utils/helpers.ts
+++ b/packages/libs/sdk/src/api/utils/helpers.ts
@@ -8,3 +8,7 @@ export const emptyPageInfo = {
 export function weiToGwei(wei: number): number {
   return +(wei / 1e9).toFixed(2);
 }
+
+export type SimplifyType<T> = T extends object
+  ? { [K in keyof T]: SimplifyType<T[K]> }
+  : T;


### PR DESCRIPTION
This simplifies the return types, so instead of showing this in the tooltip:

![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/b12f3b45-b5a1-4c4c-8d42-5918c5feb3fe)

We have a more helpful type description:

![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/3cc54895-3b16-4248-b53c-cb68f78ce881)

Side note: The `__typename` is included in the type that is generate by codegen but it's actually filtered out by the [removeNodesAndEdges](https://github.com/quiknode-labs/qn-oss/blob/main/packages/libs/sdk/src/api/utils/removeNodesAndEdges.ts) function. This is a pre-existing issue that is just illuminated by these simpler types now. I'm thinking I'm going to include the `__typename` in the results in a follow-up PR because it's really good for type guards when there are more dynamic types. For instance, the events can be 4 different types and the fields are dynamic, a type guard using `__typename` would be very helpful here