### PR TITLE
Update regex for security vuln

### DIFF
--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -15,8 +15,12 @@ function useWalletNFTs(args: Args) {
   let isSearchValid = false;
 
   if ('ensName' in args) {
+    // Prevent ReDoS attacks
+    if (args.ensName?.length > 255) throw new Error('Input too long');
     isSearchValid = ENS_REGEX.test(args.ensName);
   } else {
+    // Prevent ReDoS attacks
+    if (args.address?.length > 42) throw new Error('Input too long');
     isSearchValid = ADDRESS_REGEX.test(args.address);
   }
 

--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -8,7 +8,7 @@ import {
 
 type Args = WalletNFTsQueryVariables;
 
-const ENS_REGEX = /^[a-z]+\.eth$/;
+const ENS_REGEX = /[a-z]+\.eth/;
 const ADDRESS_REGEX = /^0x[[:alnum:]]{40}$/;
 
 function useWalletNFTs(args: Args) {

--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -8,7 +8,7 @@ import {
 
 type Args = WalletNFTsQueryVariables;
 
-const ENS_REGEX = /[a-z]+(.eth)/;
+const ENS_REGEX = /^[a-z]+\.eth$/; // Updated regex
 const ADDRESS_REGEX = /^0x[[:alnum:]]{40}$/;
 
 function useWalletNFTs(args: Args) {

--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -8,7 +8,7 @@ import {
 
 type Args = WalletNFTsQueryVariables;
 
-const ENS_REGEX = /[a-z]+\.eth/;
+const ENS_REGEX = /[a-z]+(.eth)/;
 const ADDRESS_REGEX = /^0x[[:alnum:]]{40}$/;
 
 function useWalletNFTs(args: Args) {

--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -15,11 +15,9 @@ function useWalletNFTs(args: Args) {
   let isSearchValid = false;
 
   if ('ensName' in args) {
-    // Prevent ReDoS attacks
     if (args.ensName?.length > 255) throw new Error('Input too long');
     isSearchValid = ENS_REGEX.test(args.ensName);
   } else {
-    // Prevent ReDoS attacks
     if (args.address?.length > 42) throw new Error('Input too long');
     isSearchValid = ADDRESS_REGEX.test(args.address);
   }

--- a/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
+++ b/packages/libs/ui/nft-react-hooks/src/lib/hooks/useWalletNFTs/useWalletNFTs.ts
@@ -8,7 +8,7 @@ import {
 
 type Args = WalletNFTsQueryVariables;
 
-const ENS_REGEX = /^[a-z]+\.eth$/; // Updated regex
+const ENS_REGEX = /^[a-z]+\.eth$/;
 const ADDRESS_REGEX = /^0x[[:alnum:]]{40}$/;
 
 function useWalletNFTs(args: Args) {


### PR DESCRIPTION
https://github.com/quiknode-labs/qn-oss/security/code-scanning/2

Going with this approach (but adjusted for the expected number of characters for the fields):

> It is not immediately obvious how to rewrite this regular expression to avoid the problem. However, you can mitigate performance issues by limiting the length to 1000 characters, which will always finish in a reasonable amount of time.