### PR TITLE
Adds default and typesVersions to package.json

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -48,11 +48,19 @@
     },
     "./api": {
       "import": "./esm/src/api/index.js",
+      "default": "./cjs/src/api/index.js",
       "types": "./esm/src/api/index.d.ts"
     },
     "./core": {
       "import": "./esm/src/core/index.js",
+      "default": "./cjs/src/core/index.js",
       "types": "./esm/src/core/index.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "api": ["./esm/src/api/index.d.ts"],
+      "core": ["./esm/src/core/index.d.ts"]
     }
   }
 }

--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -59,8 +59,12 @@
   },
   "typesVersions": {
     "*": {
-      "api": ["./esm/src/api/index.d.ts"],
-      "core": ["./esm/src/core/index.d.ts"]
+      "api": [
+        "./esm/src/api/index.d.ts"
+      ],
+      "core": [
+        "./esm/src/core/index.d.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
Adding `typesVersions` since this is [what older versions of typescripts use to find types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#exports-is-prioritized-over-typesversions)

With this, you can now do `import Core from @quicknode/sdk/core` for tree-shaking and it will correctly type the object with older versions of typescript

Also, this adds the `default` to `exports`, which allows typescript to pick up on `const Core = require("@quicknode/sdk").Core` and correctly type `Core`