### PR TITLE
Add graphql dep directly

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -15,8 +15,9 @@
     "@urql/core": "^4.0.7",
     "@urql/exchange-graphcache": "^6.0.4",
     "cross-fetch": "^3.1.6",
-    "viem": "^1.2.0",
+    "graphql": "^16.6.0",
     "tslib": "^2.5.3",
+    "viem": "^1.2.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {
@@ -35,7 +36,6 @@
     "@types/supertest": "^2.0.12",
     "dotenv": "^16.0.3",
     "eslint-plugin-no-only-tests": "^3.1.0",
-    "graphql": "^16.6.0",
     "supertest": "^6.3.3"
   },
   "scripts": {


### PR DESCRIPTION
From error in production build:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'graphql' imported from /<redacted>/qn_sdk_ts/node_modules/@quicknode/sdk/esm/src/api/graphql/modifyQueryForChain.js
```

because we are [importing directly from graphql now](https://github.com/quiknode-labs/qn-oss/blob/bb88fb40bd266ca4b099ad4ccd1133b28b42a1ba/packages/libs/sdk/src/api/graphql/modifyQueryForChain.ts#L1)

I tested a production build and having it in `package.json` resolved this error