### PR TITLE
Update core addon qn_get_walletTokenTransactions response type

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "./cjs/index.js",
   "module": "./esm/src/index.js",
   "types": "./index.d.ts",

--- a/packages/libs/sdk/src/core/addOns/nftTokenV2/types/qn_getWalletTokenTransactions.ts
+++ b/packages/libs/sdk/src/core/addOns/nftTokenV2/types/qn_getWalletTokenTransactions.ts
@@ -30,16 +30,19 @@ export type RPCFullTokenMetadata = {
 };
 
 export type RPCTokenTransaction = {
-  name: string | null;
-  symbol: string | null;
-  decimals: string | null;
-  address: string;
-  quantityIn: string;
-  quantityOut: string;
   blockNumber: string;
   transactionHash: string;
+  toAddress: string;
+  fromAddress: string;
+  logIndex: number;
+  type: string;
   timestamp: string;
-  totalBalance: string;
+  receivedTokenContractAddress: string | null;
+  sentTokenContractAddress: string | null;
+  sentAmount: string;
+  receivedAmount: string;
+  decimalSentAmount: string;
+  decimalReceivedAmount: string;
 };
 
 export type QNGetWalletTokenTransactionsResult = {


### PR DESCRIPTION
Updates the response type with the [latest API changes](https://www.quicknode.com/docs/ethereum/qn_getWalletTokenTransactions_v2), here is example usage:

```typescript
import Core from "@quicknode/sdk/core";

const core = new Core({
  endpointUrl: "<redacted>",
  config: {
    addOns: {
      nftTokenV2: true,
    },
  },
});

const walletTokenTransactions = await core.client.qn_getWalletTokenTransactions({
  address: "0xD10E24685c7CDD3cd3BaAA86b09C92Be28c834B6",
  contract: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
})
```
and the in-editor type as an example:

![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/82d989ae-8f98-42ab-a4da-3796ac9d4196)
