### PR TITLE
Don't use urql cache and remove urql/exchange-graphcache

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@apollo/client": "^3.7.12",
     "@ethersproject/providers": "^5.7.2",
     "@urql/core": "^4.0.7",
-    "@urql/exchange-graphcache": "^6.0.4",
     "copy-webpack-plugin": "^11.0.0",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.1.5",

--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,14 +6,13 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "./cjs/index.js",
   "module": "./esm/src/index.js",
   "types": "./index.d.ts",
   "sideEffects": false,
   "dependencies": {
     "@urql/core": "^4.0.7",
-    "@urql/exchange-graphcache": "^6.0.4",
     "cross-fetch": "^3.1.6",
     "graphql": "^16.6.0",
     "klona": "^2.0.6",

--- a/packages/libs/sdk/src/api/api.ts
+++ b/packages/libs/sdk/src/api/api.ts
@@ -1,8 +1,7 @@
 import fetch from 'cross-fetch';
 import { CustomUrqlClient } from './graphql/customUrqlClient';
 import { Client, fetchExchange } from '@urql/core';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { Data, cacheExchange } from '@urql/exchange-graphcache';
+
 import {
   NftsController,
   TokensController,
@@ -78,48 +77,14 @@ export class API {
     if (this.graphApiKey) headers['x-api-key'] = this.graphApiKey;
     headers['x-quicknode-sdk'] = 'js-sdk';
     headers['x-quicknode-sdk-version'] = packageJson?.version || 'n/a';
-    const useNftKey = (data: Data) =>
-      `${data['contractAddress']}:${data['tokenId']}`;
-    const useAddressAsKey = (data: Data) => `${data['address']}`;
-    const useTransactionHashAndIndex = (data: Data) =>
-      `${data['transactionHash']}:${data['transferIndex']}`;
-    const urqlCache = cacheExchange({
-      keys: {
-        EVMSchemaType: () => null, // The entity has no key and no parent entity so effectively won't cache
-        Collection: useAddressAsKey,
-        CollectionOHLCVChart: () => null, // Entities without keys will be embedded directly on the parent entity.
-        Contract: useAddressAsKey,
-        ERC721NFT: useNftKey,
-        ERC721Collection: useAddressAsKey,
-        ERC1155NFT: useNftKey,
-        ERC1155Collection: useAddressAsKey,
-        GasPrice: () => null,
-        NFT: useNftKey,
-        NFTContract: useAddressAsKey,
-        TokenAttribute: () => null,
-        TokenContract: useAddressAsKey,
-        TokenEvent: useTransactionHashAndIndex,
-        TokenMintEvent: useTransactionHashAndIndex,
-        TokenBurnEvent: useTransactionHashAndIndex,
-        TokenSaleEvent: useTransactionHashAndIndex,
-        TokenSwapEvent: useTransactionHashAndIndex,
-        TokenTransferEvent: useTransactionHashAndIndex,
-        TokenUpload: () => null,
-        OpenSeaMetadata: () => null,
-        Transaction: (data) => `${data['hash']}`,
-        TrendingCollection: () => null,
-        Wallet: (data) => `${data['address']}`,
-        WalletNFT: () => null,
-        WalletTokenBalance: () => null,
-      },
-    });
 
     const client = new Client({
       fetch,
       url:
         process.env['NX_GRAPHQL_API_URI'] ||
         'https://api.quicknode.com/graphql',
-      exchanges: [urqlCache, fetchExchange],
+      exchanges: [fetchExchange],
+      requestPolicy: 'network-only',
       fetchOptions: () => ({ headers }),
     });
 

--- a/packages/libs/sdk/yarn.lock
+++ b/packages/libs/sdk/yarn.lock
@@ -1329,21 +1329,12 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@urql/core@>=4.0.0", "@urql/core@^4.0.7":
+"@urql/core@^4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.0.7.tgz#8918a956f8e2ffbaeb3aae58190d728813de5841"
   integrity sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
-    wonka "^6.3.2"
-
-"@urql/exchange-graphcache@^6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.4.tgz#55b9dab64369f4a887f10a1a5e5f855ba68283ae"
-  integrity sha512-fzfCUrHzhLycPRa6kYrQYryk0pwmUfeHY9Xqh11A6wtp4/diV7FASlffB5k2j3AWRBxBnqThXDssRXI/G8cACQ==
-  dependencies:
-    "@0no-co/graphql.web" "^1.0.1"
-    "@urql/core" ">=4.0.0"
     wonka "^6.3.2"
 
 "@wagmi/chains@1.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,21 +2994,12 @@
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
-"@urql/core@>=4.0.0", "@urql/core@^4.0.7":
+"@urql/core@^4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.0.7.tgz#8918a956f8e2ffbaeb3aae58190d728813de5841"
   integrity sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
-    wonka "^6.3.2"
-
-"@urql/exchange-graphcache@^6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.4.tgz#55b9dab64369f4a887f10a1a5e5f855ba68283ae"
-  integrity sha512-fzfCUrHzhLycPRa6kYrQYryk0pwmUfeHY9Xqh11A6wtp4/diV7FASlffB5k2j3AWRBxBnqThXDssRXI/G8cACQ==
-  dependencies:
-    "@0no-co/graphql.web" "^1.0.1"
-    "@urql/core" ">=4.0.0"
     wonka "^6.3.2"
 
 "@wagmi/chains@1.2.0":


### PR DESCRIPTION
Because we don't use introspection, using the cache creates a lot of warnings, it's best to disable it so users don't see warnings in development and we are certain the data being returned is always up-to-date.