### PR TITLE
Update urql logger to not show warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@apollo/client": "^3.7.12",
     "@ethersproject/providers": "^5.7.2",
-    "@urql/core": "^4.0.7",
-    "@urql/exchange-graphcache": "^6.0.4",
+    "@urql/core": "^4.2.0",
+    "@urql/exchange-graphcache": "^6.4.0",
     "copy-webpack-plugin": "^11.0.0",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.1.5",

--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,14 +6,14 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "./cjs/index.js",
   "module": "./esm/src/index.js",
   "types": "./index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@urql/core": "^4.0.7",
-    "@urql/exchange-graphcache": "^6.0.4",
+    "@urql/core": "^4.2.0",
+    "@urql/exchange-graphcache": "^6.4.0",
     "cross-fetch": "^3.1.6",
     "graphql": "^16.6.0",
     "klona": "^2.0.6",

--- a/packages/libs/sdk/src/api/api.ts
+++ b/packages/libs/sdk/src/api/api.ts
@@ -84,6 +84,17 @@ export class API {
     const useTransactionHashAndIndex = (data: Data) =>
       `${data['transactionHash']}:${data['transferIndex']}`;
     const urqlCache = cacheExchange({
+      logger: (severity: 'debug' | 'error' | 'warn', message: string) => {
+        if (severity === 'warn' && process.env['SHOW_URQL_WARNINGS']) {
+          console.warn(message);
+        }
+        if (severity === 'debug' && process.env['SHOW_URQL_DEBUG']) {
+          console.debug(message);
+        }
+        if (severity === 'error') {
+          console.error(message);
+        }
+      },
       keys: {
         EVMSchemaType: () => null, // The entity has no key and no parent entity so effectively won't cache
         Collection: useAddressAsKey,

--- a/packages/libs/sdk/yarn.lock
+++ b/packages/libs/sdk/yarn.lock
@@ -1329,21 +1329,21 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@urql/core@>=4.0.0", "@urql/core@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.0.7.tgz#8918a956f8e2ffbaeb3aae58190d728813de5841"
-  integrity sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==
+"@urql/core@>=4.2.0", "@urql/core@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.2.0.tgz#7715491bc07e4af8b5d5039a19ea562cd109ae2f"
+  integrity sha512-GRkZ4kECR9UohWAjiSk2UYUetco6/PqSrvyC4AH6g16tyqEShA63M232cfbE1J9XJPaGNjia14Gi+oOqzp144w==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
     wonka "^6.3.2"
 
-"@urql/exchange-graphcache@^6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.4.tgz#55b9dab64369f4a887f10a1a5e5f855ba68283ae"
-  integrity sha512-fzfCUrHzhLycPRa6kYrQYryk0pwmUfeHY9Xqh11A6wtp4/diV7FASlffB5k2j3AWRBxBnqThXDssRXI/G8cACQ==
+"@urql/exchange-graphcache@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.4.0.tgz#5a3808625cab54f81d249320610564cf48e24398"
+  integrity sha512-VgcPdDNR3hSJDuf+mj0OZWzOzQccA8vT8xphxtO1MoJlgv1A4VhjLd75pjVvGz29ZHN90jEbdyBKJz6GShT7qA==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
-    "@urql/core" ">=4.0.0"
+    "@urql/core" ">=4.2.0"
     wonka "^6.3.2"
 
 "@wagmi/chains@1.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,21 +2994,21 @@
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
-"@urql/core@>=4.0.0", "@urql/core@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.0.7.tgz#8918a956f8e2ffbaeb3aae58190d728813de5841"
-  integrity sha512-UtZ9oSbSFODXzFydgLCXpAQz26KGT1d6uEfcylKphiRWNXSWZi8k7vhJXNceNm/Dn0MiZ+kaaJHKcnGY1jvHRQ==
+"@urql/core@>=4.2.0", "@urql/core@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.2.0.tgz#7715491bc07e4af8b5d5039a19ea562cd109ae2f"
+  integrity sha512-GRkZ4kECR9UohWAjiSk2UYUetco6/PqSrvyC4AH6g16tyqEShA63M232cfbE1J9XJPaGNjia14Gi+oOqzp144w==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
     wonka "^6.3.2"
 
-"@urql/exchange-graphcache@^6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.0.4.tgz#55b9dab64369f4a887f10a1a5e5f855ba68283ae"
-  integrity sha512-fzfCUrHzhLycPRa6kYrQYryk0pwmUfeHY9Xqh11A6wtp4/diV7FASlffB5k2j3AWRBxBnqThXDssRXI/G8cACQ==
+"@urql/exchange-graphcache@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@urql/exchange-graphcache/-/exchange-graphcache-6.4.0.tgz#5a3808625cab54f81d249320610564cf48e24398"
+  integrity sha512-VgcPdDNR3hSJDuf+mj0OZWzOzQccA8vT8xphxtO1MoJlgv1A4VhjLd75pjVvGz29ZHN90jEbdyBKJz6GShT7qA==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
-    "@urql/core" ">=4.0.0"
+    "@urql/core" ">=4.2.0"
     wonka "^6.3.2"
 
 "@wagmi/chains@1.2.0":


### PR DESCRIPTION
With my issue fixed 🎉 https://github.com/urql-graphql/urql/issues/3404, we can use urql to hide warnings now unless we explicitly allow them, so the end user doesn't see them

Before (warnings on top)
![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/bd17d476-4206-4557-a662-039ef6709847)

After (no warnings)
![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/0555aa32-16e2-45a7-b2b4-2c09c07fd2b8)
