### PR TITLE
Adding Solana support

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -10,6 +10,7 @@ env:
   # This should match the hostname of the endpoint used to record the pollyjs test
   # This shouldn't be a valid endpoint URL, the auth token should be redacted
   QUICKNODE_ENDPOINT_URL: ${{ secrets.QUICKNODE_ENDPOINT_URL }}
+  QUICKNODE_SOLANA_ENDPOINT_URL: ${{ secrets.QUICKNODE_SOLANA_ENDPOINT_URL }}
 jobs:
   libs-sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -9,6 +9,7 @@ env:
   # This should match the hostname of the endpoint used to record the pollyjs test
   # This shouldn't be a valid endpoint URL, the auth token should be redacted
   QUICKNODE_ENDPOINT_URL: ${{ secrets.QUICKNODE_ENDPOINT_URL }}
+  QUICKNODE_SOLANA_ENDPOINT_URL: ${{ secrets.QUICKNODE_SOLANA_ENDPOINT_URL }}
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.12",
     "@ethersproject/providers": "^5.7.2",
+    "@solana/web3.js": "^1.91",
     "@urql/core": "^4.2.0",
     "@urql/exchange-graphcache": "^6.4.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "2.2.3",
+  "version": "2.2.0",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",

--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "2.1.3",
+  "version": "2.2.3",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",
@@ -21,6 +21,7 @@
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
+    "@solana/web3.js": "^1.91",
     "@types/jest": "^29.5.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.13.0",
@@ -40,12 +41,20 @@
       "import": "./esm/core/index.js",
       "default": "./cjs/core/index.js",
       "types": "./esm/core/index.d.ts"
+    },
+    "./solana": {
+      "import": "./esm/solana/index.js",
+      "default": "./cjs/solana/index.js",
+      "types": "./esm/solana/index.d.ts"
     }
   },
   "typesVersions": {
     "*": {
       "core": [
         "./esm/core/index.d.ts"
+      ],
+      "solana": [
+        "./esm/solana/index.d.ts"
       ]
     }
   }

--- a/packages/libs/sdk/rollup.mjs
+++ b/packages/libs/sdk/rollup.mjs
@@ -75,4 +75,12 @@ export default [
       format: 'es',
     },
   }),
+  bundle({
+    input: toAbsoluteDir('./src/solana/index.ts'),
+    plugins: [dts()], // Rollup the .d.ts files
+    output: {
+      file: `${buildRootDir}/esm/solana/index.d.ts`,
+      format: 'es',
+    },
+  }),
 ];

--- a/packages/libs/sdk/spec/recordings/solana-client-basic-function_3296580151/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-basic-function_3296580151/recording.har
@@ -1,0 +1,136 @@
+{
+  "log": {
+    "_recordingName": "solana-client-basic-function",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "550dce128d20098f32afe7eb6ab6d1df",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 92,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "92"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 373,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"getSlot\",\"jsonrpc\":\"2.0\",\"params\":[],\"id\":\"e615b3cd-bba2-4a5d-94fa-f58661208925\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 81,
+          "content": {
+            "mimeType": "application/json",
+            "size": 81,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":254810311,\"id\":\"e615b3cd-bba2-4a5d-94fa-f58661208925\"}\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "22f41c00835b58fb"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 17 Mar 2024 22:47:01 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "81"
+            }
+          ],
+          "headersSize": 385,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-17T22:47:00.390Z",
+        "time": 1044,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1044
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
@@ -1,134 +1,12 @@
 {
   "log": {
-    "_recordingName": "solana-client-sendSmartTransaction",
+    "_recordingName": "solana-client-prepareSmartTransaction",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
       "version": "6.0.5"
     },
     "entries": [
-      {
-        "_id": "acbd44d2b59f8bb85098f4a9278b5d64",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 103,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "solana-client",
-              "value": "js/0.0.0-development"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "103"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
-            }
-          ],
-          "headersSize": 374,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"method\":\"getLatestBlockhash\",\"jsonrpc\":\"2.0\",\"params\":[],\"id\":\"743e324e-863f-42c9-8e37-64d4f7bd053b\"}"
-          },
-          "queryString": [],
-          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
-        },
-        "response": {
-          "bodySize": 225,
-          "content": {
-            "mimeType": "application/json",
-            "size": 225,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.25\",\"slot\":254810612},\"value\":{\"blockhash\":\"81JmjjAtNSg7bFFigtrr19AUYArC9Pa2dKyCkYcZ1hX\",\"lastValidBlockHeight\":235321655}},\"id\":\"743e324e-863f-42c9-8e37-64d4f7bd053b\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-headers",
-              "value": "Content-Type,Authorization,User-Agent,solana-client"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "GET, POST, OPTIONS"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-host-id",
-              "value": "a92bc58d2be2e5b8"
-            },
-            {
-              "name": "x-node-id",
-              "value": "solana_solana-mainnet_jfk"
-            },
-            {
-              "name": "date",
-              "value": "Sun, 17 Mar 2024 22:49:03 GMT"
-            },
-            {
-              "name": "content-length",
-              "value": "225"
-            }
-          ],
-          "headersSize": 386,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-03-17T22:49:03.014Z",
-        "time": 416,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 416
-        }
-      },
       {
         "_id": "d29a8a03e7650c1d4c9f0dd702fa1079",
         "_order": 0,
@@ -188,7 +66,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 713,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":254922416},\"per_compute_unit\":{\"extreme\":2158180,\"high\":250000,\"low\":20430,\"medium\":71428,\"percentiles\":{\"10\":1127,\"100\":8333333333,\"15\":2162,\"20\":4579,\"25\":9868,\"30\":10714,\"35\":15000,\"40\":20430,\"45\":30000,\"5\":666,\"50\":46691,\"55\":56000,\"60\":71428,\"65\":101146,\"70\":142857,\"75\":200000,\"80\":250000,\"85\":433208,\"90\":714286,\"95\":2158180}},\"per_transaction\":{\"extreme\":5000000,\"high\":433208,\"low\":50000,\"medium\":140000,\"percentiles\":{\"10\":1388,\"100\":8333333333,\"15\":5003,\"20\":10714,\"25\":19302,\"30\":25546,\"35\":40000,\"40\":50000,\"45\":71428,\"5\":1,\"50\":95010,\"55\":101773,\"60\":140000,\"65\":165411,\"70\":222222,\"75\":345382,\"80\":433208,\"85\":620015,\"90\":1021861,\"95\":5000000}}},\"id\":1}"
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":254923002},\"per_compute_unit\":{\"extreme\":1842896,\"high\":250050,\"low\":28315,\"medium\":77957,\"percentiles\":{\"10\":1580,\"100\":8121677495,\"15\":2935,\"20\":7021,\"25\":10714,\"30\":15000,\"35\":20000,\"40\":28315,\"45\":40000,\"5\":721,\"50\":50003,\"55\":71428,\"60\":77957,\"65\":105160,\"70\":150000,\"75\":210526,\"80\":250050,\"85\":493403,\"90\":779577,\"95\":1842896}},\"per_transaction\":{\"extreme\":3295320,\"high\":500000,\"low\":49216,\"medium\":110000,\"percentiles\":{\"10\":700,\"100\":8121677495,\"15\":3182,\"20\":10000,\"25\":15189,\"30\":23004,\"35\":35400,\"40\":49216,\"45\":67500,\"5\":0,\"50\":83683,\"55\":100000,\"60\":110000,\"65\":150000,\"70\":200000,\"75\":250000,\"80\":500000,\"85\":762300,\"90\":1021245,\"95\":3295320}}},\"id\":1}"
           },
           "cookies": [],
           "headers": [
@@ -226,7 +104,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 18 Mar 2024 11:46:52 GMT"
+              "value": "Mon, 18 Mar 2024 11:50:58 GMT"
             },
             {
               "name": "content-length",
@@ -243,8 +121,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-03-18T11:46:52.103Z",
-        "time": 794,
+        "startedDateTime": "2024-03-18T11:50:57.611Z",
+        "time": 694,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -252,11 +130,133 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 794
+          "wait": 694
         }
       },
       {
-        "_id": "68f63970f5f951a23dc69856a0693356",
+        "_id": "acbd44d2b59f8bb85098f4a9278b5d64",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 103,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "103"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 374,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"getLatestBlockhash\",\"jsonrpc\":\"2.0\",\"params\":[],\"id\":\"e6aa9c8c-0dd5-4e9a-a5af-78a7461c5c74\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 226,
+          "content": {
+            "mimeType": "application/json",
+            "size": 226,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.25\",\"slot\":254922957},\"value\":{\"blockhash\":\"2acCVCzy5dPndawWVvTYDoHWqoe4dXo1srhWQ4W5btnb\",\"lastValidBlockHeight\":235430258}},\"id\":\"e6aa9c8c-0dd5-4e9a-a5af-78a7461c5c74\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "a92bc58d2be2e5b8"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 18 Mar 2024 11:50:58 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "226"
+            }
+          ],
+          "headersSize": 386,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-18T11:50:58.316Z",
+        "time": 490,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 490
+        }
+      },
+      {
+        "_id": "cbce735a79b1ee99963508106a2c04fc",
         "_order": 0,
         "cache": {},
         "request": {
@@ -304,7 +304,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDBBcBAAAAAAABAAkDBBcBAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"ed52f27a-d869-4d9e-8b23-f4de1c265760\"}"
+            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDhTABAAAAAAABAAkDhTABAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"678acd71-b6f1-4894-a147-62305566965f\"}"
           },
           "queryString": [],
           "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
@@ -314,7 +314,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 221,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.26\",\"slot\":254922385},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"ed52f27a-d869-4d9e-8b23-f4de1c265760\"}\n"
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.24\",\"slot\":254923084},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"678acd71-b6f1-4894-a147-62305566965f\"}\n"
           },
           "cookies": [],
           "headers": [
@@ -344,7 +344,7 @@
             },
             {
               "name": "x-host-id",
-              "value": "c934868888f346eb"
+              "value": "221ac2bcbd1ac759"
             },
             {
               "name": "x-node-id",
@@ -352,7 +352,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 18 Mar 2024 11:46:53 GMT"
+              "value": "Mon, 18 Mar 2024 11:51:55 GMT"
             },
             {
               "name": "content-length",
@@ -365,8 +365,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-03-18T11:46:53.328Z",
-        "time": 488,
+        "startedDateTime": "2024-03-18T11:51:54.745Z",
+        "time": 691,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -374,129 +374,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 488
-        }
-      },
-      {
-        "_id": "f9be7571431f5766900ea4c5eed30d0f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 385,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "solana-client",
-              "value": "js/0.0.0-development"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "385"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
-            }
-          ],
-          "headersSize": 374,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"method\":\"sendTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AduSSFWCowDxfELbBpmhfWTGny16JMwmTurwnRVS/Z7QwBdVKAMXhg84cxxHks8yJh03PW9/X4TEOhHGH/7GiwEBAAEChBHHMlEWdcKh7owGV2dOVR/Wrnn95SYJDgXxHb7aYygDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAHLaYBE/pnlByh2qLtexxJv4xuqEN/9aSFyVZcWLYn+AQEACQMEFwEAAAAAAA==\",{\"encoding\":\"base64\",\"skipPreflight\":true}],\"id\":\"128e0f1d-eaa6-4039-b4b7-4b6a674af25a\"}"
-          },
-          "queryString": [],
-          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
-        },
-        "response": {
-          "bodySize": 162,
-          "content": {
-            "mimeType": "application/json",
-            "size": 162,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":\"5PckAvNaSkW2fgWpk2tkeAz8finKFceTqCbJn319yUep8MxBCkFhPdbS4N5TJYbWf6rc5JxZ1uwE3TL3cvj1Skgx\",\"id\":\"128e0f1d-eaa6-4039-b4b7-4b6a674af25a\"}\n"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-headers",
-              "value": "Content-Type,Authorization,User-Agent,solana-client"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "GET, POST, OPTIONS"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-host-id",
-              "value": "567d68f1d2c02130"
-            },
-            {
-              "name": "x-node-id",
-              "value": "solana_solana-mainnet_jfk"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 18 Mar 2024 11:46:53 GMT"
-            },
-            {
-              "name": "content-length",
-              "value": "162"
-            }
-          ],
-          "headersSize": 386,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-03-18T11:46:53.827Z",
-        "time": 134,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 134
+          "wait": 691
         }
       }
     ],

--- a/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
@@ -256,7 +256,7 @@
         }
       },
       {
-        "_id": "dfde9d149401a9820697713ebf21561c",
+        "_id": "80e7559f462440d7ee899caa4a6cdfb3",
         "_order": 0,
         "cache": {},
         "request": {
@@ -304,7 +304,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAoK0lB6R81kfRL1p2UGckZ+zqYxCrMvGrr6YPYFdNhWLAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDhTABAAAAAAABAAkDhTABAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"8b23ebb1-5a19-493d-a96e-c3348d502b3b\"}"
+            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAoQRxzJRFnXCoe6MBldnTlUf1q55/eUmCQ4F8R2+2mMoAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDhTABAAAAAAABAAkDhTABAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"adaa266b-07bb-447d-8668-2debebcce681\"}"
           },
           "queryString": [],
           "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
@@ -314,7 +314,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 221,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.22\",\"slot\":254928510},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"8b23ebb1-5a19-493d-a96e-c3348d502b3b\"}\n"
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.26\",\"slot\":255134976},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"adaa266b-07bb-447d-8668-2debebcce681\"}\n"
           },
           "cookies": [],
           "headers": [
@@ -344,7 +344,7 @@
             },
             {
               "name": "x-host-id",
-              "value": "6961bee99b20ac4a"
+              "value": "4773c6f26c8f4557"
             },
             {
               "name": "x-node-id",
@@ -352,7 +352,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 18 Mar 2024 12:29:22 GMT"
+              "value": "Tue, 19 Mar 2024 12:33:00 GMT"
             },
             {
               "name": "content-length",
@@ -365,8 +365,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-03-18T12:29:22.450Z",
-        "time": 221,
+        "startedDateTime": "2024-03-19T12:32:59.870Z",
+        "time": 1133,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -374,7 +374,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 221
+          "wait": 1133
         }
       }
     ],

--- a/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-prepareSmartTransaction_3623416322/recording.har
@@ -256,7 +256,7 @@
         }
       },
       {
-        "_id": "cbce735a79b1ee99963508106a2c04fc",
+        "_id": "dfde9d149401a9820697713ebf21561c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -304,7 +304,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDhTABAAAAAAABAAkDhTABAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"678acd71-b6f1-4894-a147-62305566965f\"}"
+            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAoK0lB6R81kfRL1p2UGckZ+zqYxCrMvGrr6YPYFdNhWLAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDhTABAAAAAAABAAkDhTABAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"8b23ebb1-5a19-493d-a96e-c3348d502b3b\"}"
           },
           "queryString": [],
           "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
@@ -314,7 +314,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 221,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.24\",\"slot\":254923084},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"678acd71-b6f1-4894-a147-62305566965f\"}\n"
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.22\",\"slot\":254928510},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"8b23ebb1-5a19-493d-a96e-c3348d502b3b\"}\n"
           },
           "cookies": [],
           "headers": [
@@ -344,7 +344,7 @@
             },
             {
               "name": "x-host-id",
-              "value": "221ac2bcbd1ac759"
+              "value": "6961bee99b20ac4a"
             },
             {
               "name": "x-node-id",
@@ -352,7 +352,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 18 Mar 2024 11:51:55 GMT"
+              "value": "Mon, 18 Mar 2024 12:29:22 GMT"
             },
             {
               "name": "content-length",
@@ -365,8 +365,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-03-18T11:51:54.745Z",
-        "time": 691,
+        "startedDateTime": "2024-03-18T12:29:22.450Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -374,7 +374,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 691
+          "wait": 221
         }
       }
     ],

--- a/packages/libs/sdk/spec/recordings/solana-client-sendSmartTransaction_2450286823/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-sendSmartTransaction_2450286823/recording.har
@@ -256,128 +256,6 @@
         }
       },
       {
-        "_id": "68f63970f5f951a23dc69856a0693356",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 432,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "solana-client",
-              "value": "js/0.0.0-development"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "432"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
-            }
-          ],
-          "headersSize": 374,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDBBcBAAAAAAABAAkDBBcBAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"ed52f27a-d869-4d9e-8b23-f4de1c265760\"}"
-          },
-          "queryString": [],
-          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
-        },
-        "response": {
-          "bodySize": 221,
-          "content": {
-            "mimeType": "application/json",
-            "size": 221,
-            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.26\",\"slot\":254922385},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"ed52f27a-d869-4d9e-8b23-f4de1c265760\"}\n"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-headers",
-              "value": "Content-Type,Authorization,User-Agent,solana-client"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "GET, POST, OPTIONS"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "x-host-id",
-              "value": "c934868888f346eb"
-            },
-            {
-              "name": "x-node-id",
-              "value": "solana_solana-mainnet_jfk"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 18 Mar 2024 11:46:53 GMT"
-            },
-            {
-              "name": "content-length",
-              "value": "221"
-            }
-          ],
-          "headersSize": 386,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-03-18T11:46:53.328Z",
-        "time": 488,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 488
-        }
-      },
-      {
         "_id": "f9be7571431f5766900ea4c5eed30d0f",
         "_order": 0,
         "cache": {},
@@ -497,6 +375,128 @@
           "send": 0,
           "ssl": -1,
           "wait": 134
+        }
+      },
+      {
+        "_id": "d84468653a893bf1ce9d5dfb75d7b369",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 432,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "432"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 374,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAoQRxzJRFnXCoe6MBldnTlUf1q55/eUmCQ4F8R2+2mMoAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAkDBBcBAAAAAAABAAkDBBcBAAAAAAAA\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"da6652d2-9fcd-4ac1-bc1d-17242d415cc0\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json",
+            "size": 221,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.26\",\"slot\":254928509},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"da6652d2-9fcd-4ac1-bc1d-17242d415cc0\"}\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "bd35ac261f619f05"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 18 Mar 2024 12:29:22 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "221"
+            }
+          ],
+          "headersSize": 386,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-18T12:29:21.768Z",
+        "time": 532,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 532
         }
       }
     ],

--- a/packages/libs/sdk/spec/recordings/solana-client-sendSmartTransaction_2450286823/recording.har
+++ b/packages/libs/sdk/spec/recordings/solana-client-sendSmartTransaction_2450286823/recording.har
@@ -1,0 +1,506 @@
+{
+  "log": {
+    "_recordingName": "solana-client-sendSmartTransaction",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "9fe398be7487c66224555bd974d9708b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 89,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "89"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 355,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"qn_estimatePriorityFees\",\"params\":{\"last_n_blocks\":10},\"id\":1,\"jsonrpc\":\"2.0\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 720,
+          "content": {
+            "mimeType": "application/json",
+            "size": 720,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":254810651},\"per_compute_unit\":{\"extreme\":1396328,\"high\":269696,\"low\":35714,\"medium\":100000,\"percentiles\":{\"10\":875,\"100\":231251300,\"15\":1505,\"20\":2193,\"25\":9545,\"30\":19759,\"35\":24687,\"40\":35714,\"45\":53287,\"5\":647,\"50\":71428,\"55\":100000,\"60\":100000,\"65\":138172,\"70\":168104,\"75\":214288,\"80\":269696,\"85\":432355,\"90\":688327,\"95\":1396328}},\"per_transaction\":{\"extreme\":3174711,\"high\":500000,\"low\":100000,\"medium\":154040,\"percentiles\":{\"10\":3333,\"100\":231251300,\"15\":16000,\"20\":25623,\"25\":46691,\"30\":71428,\"35\":86838,\"40\":100000,\"45\":100000,\"5\":736,\"50\":100000,\"55\":140000,\"60\":154040,\"65\":211012,\"70\":269483,\"75\":351550,\"80\":500000,\"85\":826943,\"90\":1053319,\"95\":3174711}}},\"id\":1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "bdc3c6b0fcc2f18f"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 17 Mar 2024 22:49:03 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "720"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-17T22:49:02.479Z",
+        "time": 520,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 520
+        }
+      },
+      {
+        "_id": "acbd44d2b59f8bb85098f4a9278b5d64",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 103,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "103"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 374,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"getLatestBlockhash\",\"jsonrpc\":\"2.0\",\"params\":[],\"id\":\"743e324e-863f-42c9-8e37-64d4f7bd053b\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 225,
+          "content": {
+            "mimeType": "application/json",
+            "size": 225,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.25\",\"slot\":254810612},\"value\":{\"blockhash\":\"81JmjjAtNSg7bFFigtrr19AUYArC9Pa2dKyCkYcZ1hX\",\"lastValidBlockHeight\":235321655}},\"id\":\"743e324e-863f-42c9-8e37-64d4f7bd053b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "a92bc58d2be2e5b8"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 17 Mar 2024 22:49:03 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "225"
+            }
+          ],
+          "headersSize": 386,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-17T22:49:03.014Z",
+        "time": 416,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 416
+        }
+      },
+      {
+        "_id": "d40204c9d7fa8c75b674051536586596",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 428,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "428"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 374,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"simulateTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAoQRxzJRFnXCoe6MBldnTlUf1q55/eUmCQ4F8R2+2mMoAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAUCwFwVAAEACQOghgEAAAAAAAA=\",{\"replaceRecentBlockhash\":true,\"sigVerify\":false,\"encoding\":\"base64\"}],\"id\":\"143a48fb-65e9-4f38-bce2-59989bf0ffdb\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json",
+            "size": 221,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"apiVersion\":\"1.17.24\",\"slot\":254810875},\"value\":{\"accounts\":null,\"err\":\"AccountNotFound\",\"logs\":[],\"returnData\":null,\"unitsConsumed\":0}},\"id\":\"143a48fb-65e9-4f38-bce2-59989bf0ffdb\"}\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "7df076da70980964"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 17 Mar 2024 22:50:51 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "221"
+            }
+          ],
+          "headersSize": 386,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-17T22:50:50.384Z",
+        "time": 457,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 457
+        }
+      },
+      {
+        "_id": "9ab017fa768bd6818f7e168be8f93067",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 400,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "solana-client",
+              "value": "js/0.0.0-development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "400"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "alien-lingering-fire.solana-mainnet.quiknode.pro"
+            }
+          ],
+          "headersSize": 374,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"method\":\"sendTransaction\",\"jsonrpc\":\"2.0\",\"params\":[\"AR+O2oVw/dL/ScU6fkVGNhwzD5895HOiamWuPv7YZVw1dpPbGhJhPt/1QfJCrzua0C2TkVkHTPkP8wTS3mxgqg8BAAEChBHHMlEWdcKh7owGV2dOVR/Wrnn95SYJDgXxHb7aYygDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAHLaYBE/pnlByh2qLtexxJv4xuqEN/9aSFyVZcWLYn+AQEACQOghgEAAAAAAA==\",{\"encoding\":\"base64\",\"maxRetries\":0,\"skipPreflight\":true}],\"id\":\"7070c252-e2fd-45a1-82a0-73c3c2dead4d\"}"
+          },
+          "queryString": [],
+          "url": "https://alien-lingering-fire.solana-mainnet.quiknode.pro"
+        },
+        "response": {
+          "bodySize": 161,
+          "content": {
+            "mimeType": "application/json",
+            "size": 161,
+            "text": "{\"jsonrpc\":\"2.0\",\"result\":\"dbW8AT3NwaUxEwM9VND16EJeeD8ecusCm3rD8GgVYZdrnFd1WzSydTQDMdzLLYcPJ1nhUFpGwtsZRjAyNruowmp\",\"id\":\"7070c252-e2fd-45a1-82a0-73c3c2dead4d\"}\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "Content-Type,Authorization,User-Agent,solana-client"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, POST, OPTIONS"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-host-id",
+              "value": "b7ab2b610219cdc4"
+            },
+            {
+              "name": "x-node-id",
+              "value": "solana_solana-mainnet_jfk"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 17 Mar 2024 22:50:51 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "161"
+            }
+          ],
+          "headersSize": 386,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-03-17T22:50:50.857Z",
+        "time": 133,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 133
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/libs/sdk/spec/solana/client.ts
+++ b/packages/libs/sdk/spec/solana/client.ts
@@ -3,7 +3,7 @@ import { Solana, SolanaClientArgs } from '../../src';
 const solanaOpts: SolanaClientArgs = {
   endpointUrl:
     process.env['QUICKNODE_SOLANA_ENDPOINT_URL'] ||
-    'thisisnotanendpoint.example.com',
+    'https://thisisnotanendpoint.example.com',
 };
 
 export const solana = new Solana(solanaOpts);

--- a/packages/libs/sdk/spec/solana/client.ts
+++ b/packages/libs/sdk/spec/solana/client.ts
@@ -1,0 +1,9 @@
+import { Solana, SolanaClientArgs } from '../../src';
+
+const solanaOpts: SolanaClientArgs = {
+  endpointUrl:
+    process.env['QUICKNODE_SOLANA_ENDPOINT_URL'] ||
+    'thisisnotanendpoint.example.com',
+};
+
+export const solana = new Solana(solanaOpts);

--- a/packages/libs/sdk/spec/solana/client.ts
+++ b/packages/libs/sdk/spec/solana/client.ts
@@ -3,7 +3,7 @@ import { Solana, SolanaClientArgs } from '../../src';
 const solanaOpts: SolanaClientArgs = {
   endpointUrl:
     process.env['QUICKNODE_SOLANA_ENDPOINT_URL'] ||
-    'https://thisisnotanendpoint.example.com',
+    'https://thisisnotasolanaendpoint.example.com',
 };
 
 export const solana = new Solana(solanaOpts);

--- a/packages/libs/sdk/spec/solana/solanaClient.test.ts
+++ b/packages/libs/sdk/spec/solana/solanaClient.test.ts
@@ -45,13 +45,18 @@ describe('solana client', () => {
     await withPolly(
       {
         recordingName: 'solana-client-prepareSmartTransaction',
-        recordIfMissing: true,
       },
       async () => {
         const transaction = new Transaction();
         const feeLevel = 'medium';
-        await expect(solana.prepareSmartTransaction(transaction, feeLevel))
-          .resolves.toMatchInlineSnapshot(`
+        const keypair = Keypair.generate();
+        await expect(
+          solana.prepareSmartTransaction(
+            transaction,
+            keypair.publicKey,
+            feeLevel
+          )
+        ).resolves.toMatchInlineSnapshot(`
           Object {
             "feePayer": null,
             "instructions": Array [

--- a/packages/libs/sdk/spec/solana/solanaClient.test.ts
+++ b/packages/libs/sdk/spec/solana/solanaClient.test.ts
@@ -3,10 +3,10 @@ import { Transaction, Keypair } from '@solana/web3.js';
 import withPolly from '../testSetup/pollyTestSetup';
 
 describe('solana client', () => {
-  let keypair: Keypair;
+  let keyPair: Keypair;
 
   beforeAll(() => {
-    keypair = Keypair.fromSecretKey(
+    keyPair = Keypair.fromSecretKey(
       new Uint8Array([
         130, 116, 86, 249, 242, 108, 166, 19, 25, 227, 239, 208, 22, 150, 37,
         135, 84, 53, 70, 45, 157, 16, 240, 233, 200, 163, 11, 93, 165, 225, 199,
@@ -39,7 +39,7 @@ describe('solana client', () => {
         const transaction = new Transaction();
         const feeLevel = 'medium';
         await expect(
-          solana.sendSmartTransaction(transaction, keypair, feeLevel)
+          solana.sendSmartTransaction({ transaction, keyPair, feeLevel })
         ).resolves.toMatchInlineSnapshot(
           `"5PckAvNaSkW2fgWpk2tkeAz8finKFceTqCbJn319yUep8MxBCkFhPdbS4N5TJYbWf6rc5JxZ1uwE3TL3cvj1Skgx"`
         );
@@ -55,11 +55,11 @@ describe('solana client', () => {
         const transaction = new Transaction();
         const feeLevel = 'medium';
         await expect(
-          solana.prepareSmartTransaction(
+          solana.prepareSmartTransaction({
             transaction,
-            keypair.publicKey,
-            feeLevel
-          )
+            payerPublicKey: keyPair.publicKey,
+            feeLevel,
+          })
         ).resolves.toMatchInlineSnapshot(`
           Object {
             "feePayer": null,

--- a/packages/libs/sdk/spec/solana/solanaClient.test.ts
+++ b/packages/libs/sdk/spec/solana/solanaClient.test.ts
@@ -1,0 +1,44 @@
+import { solana } from './client';
+import { Transaction, Keypair } from '@solana/web3.js';
+import withPolly from '../testSetup/pollyTestSetup';
+
+describe('solana client', () => {
+  it('should call basic solana functions', async () => {
+    await withPolly(
+      {
+        recordingName: 'solana-client-basic-function',
+      },
+      async () => {
+        await expect(
+          solana.connection.getSlot()
+        ).resolves.toMatchInlineSnapshot(`254810311`);
+      }
+    );
+  });
+
+  it('should call solana sendSmartTransaction', async () => {
+    await withPolly(
+      {
+        recordingName: 'solana-client-sendSmartTransaction',
+      },
+      async () => {
+        const transaction = new Transaction();
+        const keyPair = Keypair.fromSecretKey(
+          new Uint8Array([
+            130, 116, 86, 249, 242, 108, 166, 19, 25, 227, 239, 208, 22, 150,
+            37, 135, 84, 53, 70, 45, 157, 16, 240, 233, 200, 163, 11, 93, 165,
+            225, 199, 93, 132, 17, 199, 50, 81, 22, 117, 194, 161, 238, 140, 6,
+            87, 103, 78, 85, 31, 214, 174, 121, 253, 229, 38, 9, 14, 5, 241, 29,
+            190, 218, 99, 40,
+          ])
+        );
+        const feeLevel = 'medium';
+        await expect(
+          solana.sendSmartTransaction(transaction, keyPair, feeLevel)
+        ).resolves.toMatchInlineSnapshot(
+          `"dbW8AT3NwaUxEwM9VND16EJeeD8ecusCm3rD8GgVYZdrnFd1WzSydTQDMdzLLYcPJ1nhUFpGwtsZRjAyNruowmp"`
+        );
+      }
+    );
+  });
+});

--- a/packages/libs/sdk/spec/solana/solanaClient.test.ts
+++ b/packages/libs/sdk/spec/solana/solanaClient.test.ts
@@ -3,6 +3,20 @@ import { Transaction, Keypair } from '@solana/web3.js';
 import withPolly from '../testSetup/pollyTestSetup';
 
 describe('solana client', () => {
+  let keypair: Keypair;
+
+  beforeAll(() => {
+    keypair = Keypair.fromSecretKey(
+      new Uint8Array([
+        130, 116, 86, 249, 242, 108, 166, 19, 25, 227, 239, 208, 22, 150, 37,
+        135, 84, 53, 70, 45, 157, 16, 240, 233, 200, 163, 11, 93, 165, 225, 199,
+        93, 132, 17, 199, 50, 81, 22, 117, 194, 161, 238, 140, 6, 87, 103, 78,
+        85, 31, 214, 174, 121, 253, 229, 38, 9, 14, 5, 241, 29, 190, 218, 99,
+        40,
+      ])
+    );
+  });
+
   it('should call basic solana functions', async () => {
     await withPolly(
       {
@@ -23,18 +37,9 @@ describe('solana client', () => {
       },
       async () => {
         const transaction = new Transaction();
-        const keyPair = Keypair.fromSecretKey(
-          new Uint8Array([
-            130, 116, 86, 249, 242, 108, 166, 19, 25, 227, 239, 208, 22, 150,
-            37, 135, 84, 53, 70, 45, 157, 16, 240, 233, 200, 163, 11, 93, 165,
-            225, 199, 93, 132, 17, 199, 50, 81, 22, 117, 194, 161, 238, 140, 6,
-            87, 103, 78, 85, 31, 214, 174, 121, 253, 229, 38, 9, 14, 5, 241, 29,
-            190, 218, 99, 40,
-          ])
-        );
         const feeLevel = 'medium';
         await expect(
-          solana.sendSmartTransaction(transaction, keyPair, feeLevel)
+          solana.sendSmartTransaction(transaction, keypair, feeLevel)
         ).resolves.toMatchInlineSnapshot(
           `"5PckAvNaSkW2fgWpk2tkeAz8finKFceTqCbJn319yUep8MxBCkFhPdbS4N5TJYbWf6rc5JxZ1uwE3TL3cvj1Skgx"`
         );
@@ -49,7 +54,6 @@ describe('solana client', () => {
       async () => {
         const transaction = new Transaction();
         const feeLevel = 'medium';
-        const keypair = Keypair.generate();
         await expect(
           solana.prepareSmartTransaction(
             transaction,

--- a/packages/libs/sdk/spec/solana/solanaClient.test.ts
+++ b/packages/libs/sdk/spec/solana/solanaClient.test.ts
@@ -36,8 +36,46 @@ describe('solana client', () => {
         await expect(
           solana.sendSmartTransaction(transaction, keyPair, feeLevel)
         ).resolves.toMatchInlineSnapshot(
-          `"dbW8AT3NwaUxEwM9VND16EJeeD8ecusCm3rD8GgVYZdrnFd1WzSydTQDMdzLLYcPJ1nhUFpGwtsZRjAyNruowmp"`
+          `"5PckAvNaSkW2fgWpk2tkeAz8finKFceTqCbJn319yUep8MxBCkFhPdbS4N5TJYbWf6rc5JxZ1uwE3TL3cvj1Skgx"`
         );
+      }
+    );
+  });
+  it('should call solana prepareSmartTransaction', async () => {
+    await withPolly(
+      {
+        recordingName: 'solana-client-prepareSmartTransaction',
+        recordIfMissing: true,
+      },
+      async () => {
+        const transaction = new Transaction();
+        const feeLevel = 'medium';
+        await expect(solana.prepareSmartTransaction(transaction, feeLevel))
+          .resolves.toMatchInlineSnapshot(`
+          Object {
+            "feePayer": null,
+            "instructions": Array [
+              Object {
+                "data": Array [
+                  3,
+                  133,
+                  48,
+                  1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+                "keys": Array [],
+                "programId": "ComputeBudget111111111111111111111111111111",
+              },
+            ],
+            "nonceInfo": null,
+            "recentBlockhash": "2acCVCzy5dPndawWVvTYDoHWqoe4dXo1srhWQ4W5btnb",
+            "signers": Array [],
+          }
+        `);
       }
     );
   });

--- a/packages/libs/sdk/src/client/client.ts
+++ b/packages/libs/sdk/src/client/client.ts
@@ -1,4 +1,5 @@
 import Core from '../core';
+import Solana from '../solana';
 
 const QuickNode = {
   Core: Core,

--- a/packages/libs/sdk/src/client/client.ts
+++ b/packages/libs/sdk/src/client/client.ts
@@ -2,6 +2,7 @@ import Core from '../core';
 
 const QuickNode = {
   Core: Core,
+  Solana: Solana,
 };
 
 export default QuickNode;

--- a/packages/libs/sdk/src/index.ts
+++ b/packages/libs/sdk/src/index.ts
@@ -1,10 +1,14 @@
 import QuickNode from './client';
 import Core from './core';
+import Solana from './solana';
 import * as viem from 'viem';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import * as solanaWeb3 from '@solana/web3.js';
 
-export { Core, viem };
+export { Core, viem, Solana, solanaWeb3 };
 
 export * from './core/exportedTypes';
+export * from './solana/types';
 export * from './lib/errors';
 
 export default QuickNode;

--- a/packages/libs/sdk/src/solana/index.ts
+++ b/packages/libs/sdk/src/solana/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+import { Solana } from './solana';
+
+export default Solana;

--- a/packages/libs/sdk/src/solana/solana.ts
+++ b/packages/libs/sdk/src/solana/solana.ts
@@ -1,0 +1,134 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import {
+  Transaction,
+  Keypair,
+  ComputeBudgetProgram,
+  Connection,
+  TransactionInstruction,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import {
+  type EstimatePriorityFeesParams,
+  type PriorityFeeRequestPayload,
+  type PriorityFeeResponseData,
+  type PriorityFeeLevels,
+} from './types';
+
+export class Solana {
+  readonly endpointUrl: string;
+  readonly connection: Connection;
+
+  constructor({ endpointUrl }: { endpointUrl: string }) {
+    this.endpointUrl = endpointUrl;
+    this.connection = new Connection(endpointUrl);
+  }
+
+  async customFeeEstimateRpcStrategy(
+    transaction: Transaction,
+    mainKeyPair: Keypair
+  ) {
+    // eslint-disable-next-line prefer-const
+    let [computeUnitPriceInstruction, units, recentBlockhash] =
+      await Promise.all([
+        this.createDynamicPriorityFeeInstruction(),
+        this.getSimulationUnits(
+          this.connection,
+          transaction.instructions,
+          mainKeyPair.publicKey
+        ),
+        this.connection.getLatestBlockhash(),
+      ]);
+
+    transaction.add(computeUnitPriceInstruction);
+    if (units) {
+      units = Math.ceil(units * 1.01); // margin of error
+      transaction.add(ComputeBudgetProgram.setComputeUnitLimit({ units }));
+    }
+    transaction.feePayer = mainKeyPair.publicKey;
+    transaction.recentBlockhash = recentBlockhash.blockhash;
+    transaction.sign(mainKeyPair);
+
+    const hash = await this.connection.sendRawTransaction(
+      transaction.serialize(),
+      { skipPreflight: true, maxRetries: 0 }
+    );
+
+    return hash;
+  }
+
+  private async fetchEstimatePriorityFees({
+    last_n_blocks = 10,
+    account = undefined,
+  }: EstimatePriorityFeesParams): Promise<PriorityFeeResponseData> {
+    const params: { last_n_blocks?: number; account?: string } = {};
+    if (last_n_blocks !== undefined) {
+      params.last_n_blocks = last_n_blocks;
+    }
+    if (account !== undefined) {
+      params.account = account;
+    }
+
+    const payload: PriorityFeeRequestPayload = {
+      method: 'qn_estimatePriorityFees',
+      params,
+      id: 1,
+      jsonrpc: '2.0',
+    };
+
+    const response = await fetch(this.endpointUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data: PriorityFeeResponseData = await response.json();
+    return data;
+  }
+
+  private async createDynamicPriorityFeeInstruction(
+    feeType: PriorityFeeLevels = 'medium'
+  ) {
+    const { result } = await this.fetchEstimatePriorityFees({});
+    const priorityFee = result.per_compute_unit[feeType]; // 👈 Insert business logic to calculate fees depending on your transaction requirements (e.g., low, medium, high, or specific percentile)
+    const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: priorityFee,
+    });
+    return priorityFeeInstruction;
+  }
+
+  private async getSimulationUnits(
+    connection: Connection,
+    instructions: TransactionInstruction[],
+    payer: PublicKey
+  ): Promise<number | undefined> {
+    const testInstructions = [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+      ...instructions,
+    ];
+
+    const testVersionedTxn = new VersionedTransaction(
+      new TransactionMessage({
+        instructions: testInstructions,
+        payerKey: payer,
+        recentBlockhash: PublicKey.default.toString(),
+      }).compileToV0Message()
+    );
+
+    const simulation = await connection.simulateTransaction(testVersionedTxn, {
+      replaceRecentBlockhash: true,
+      sigVerify: false,
+    });
+    if (simulation.value.err) {
+      return undefined;
+    }
+    return simulation.value.unitsConsumed;
+  }
+}

--- a/packages/libs/sdk/src/solana/solana.ts
+++ b/packages/libs/sdk/src/solana/solana.ts
@@ -87,18 +87,8 @@ export class Solana {
     return transaction;
   }
 
-  private async createDynamicPriorityFeeInstruction(
-    feeType: PriorityFeeLevels = 'medium'
-  ) {
-    const { result } = await this.fetchEstimatePriorityFees({});
-    const priorityFee = result.per_compute_unit[feeType];
-    const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({
-      microLamports: priorityFee,
-    });
-    return priorityFeeInstruction;
-  }
-
-  private async fetchEstimatePriorityFees({
+  // Get the priority fee averages based on fee data from the latest blocks
+  async fetchEstimatePriorityFees({
     last_n_blocks = 100,
     account = undefined,
   }: EstimatePriorityFeesParams): Promise<PriorityFeeResponseData> {
@@ -136,6 +126,17 @@ export class Solana {
 
     const data: PriorityFeeResponseData = await response.json();
     return data;
+  }
+
+  private async createDynamicPriorityFeeInstruction(
+    feeType: PriorityFeeLevels = 'medium'
+  ) {
+    const { result } = await this.fetchEstimatePriorityFees({});
+    const priorityFee = result.per_compute_unit[feeType];
+    const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({
+      microLamports: priorityFee,
+    });
+    return priorityFeeInstruction;
   }
 
   private async getSimulationUnits(

--- a/packages/libs/sdk/src/solana/types.ts
+++ b/packages/libs/sdk/src/solana/types.ts
@@ -61,3 +61,7 @@ export interface EstimatePriorityFeesParams {
   // The program account to use for fetching the local estimate (e.g., Jupiter: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4)
   account?: string;
 }
+
+export interface SolanaClientArgs {
+  endpointUrl: string;
+}

--- a/packages/libs/sdk/src/solana/types.ts
+++ b/packages/libs/sdk/src/solana/types.ts
@@ -1,3 +1,5 @@
+import { Transaction, Keypair, PublicKey, SendOptions } from '@solana/web3.js';
+
 type PercentileRangeUnion =
   | '0'
   | '5'
@@ -64,4 +66,18 @@ export interface EstimatePriorityFeesParams {
 
 export interface SolanaClientArgs {
   endpointUrl: string;
+}
+
+export interface SmartTransactionBaseArgs {
+  transaction: Transaction;
+  feeLevel?: PriorityFeeLevels;
+}
+
+export interface PrepareSmartTransactionArgs extends SmartTransactionBaseArgs {
+  payerPublicKey: PublicKey;
+}
+
+export interface SendSmartTransactionArgs extends SmartTransactionBaseArgs {
+  keyPair: Keypair;
+  sendTransactionOptions?: SendOptions;
 }

--- a/packages/libs/sdk/src/solana/types.ts
+++ b/packages/libs/sdk/src/solana/types.ts
@@ -1,0 +1,63 @@
+type PercentileRangeUnion =
+  | '0'
+  | '5'
+  | '10'
+  | '15'
+  | '20'
+  | '25'
+  | '30'
+  | '35'
+  | '40'
+  | '45'
+  | '50'
+  | '55'
+  | '60'
+  | '65'
+  | '70'
+  | '75'
+  | '80'
+  | '85'
+  | '90'
+  | '95'
+  | '100';
+
+export type PriorityFeeLevels = 'low' | 'medium' | 'high' | 'extreme';
+
+export interface PriorityFeeRequestPayload {
+  method: string;
+  params: {
+    last_n_blocks?: number;
+    account?: string;
+  };
+  id: number;
+  jsonrpc: string;
+}
+
+export interface PriorityFeeEstimates {
+  extreme: number;
+  high: number;
+  low: number;
+  medium: number;
+  percentiles: {
+    [key in PercentileRangeUnion]: number;
+  };
+}
+
+export interface PriorityFeeResponseData {
+  jsonrpc: string;
+  result: {
+    context: {
+      slot: number;
+    };
+    per_compute_unit: PriorityFeeEstimates;
+    per_transaction: PriorityFeeEstimates;
+  };
+  id: number;
+}
+
+export interface EstimatePriorityFeesParams {
+  // The number of blocks to consider for the fee estimate
+  last_n_blocks?: number;
+  // The program account to use for fetching the local estimate (e.g., Jupiter: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4)
+  account?: string;
+}

--- a/packages/libs/sdk/yarn.lock
+++ b/packages/libs/sdk/yarn.lock
@@ -28,6 +28,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.17.2", "@babel/runtime@^7.23.4":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
+  integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@jest/expect-utils@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.5.0.tgz#f74fad6b6e20f924582dc8ecbf2cb800fe43a036"
@@ -61,12 +68,19 @@
   dependencies:
     "@noble/hashes" "1.3.2"
 
+"@noble/curves@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
+  integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
+  dependencies:
+    "@noble/hashes" "1.3.3"
+
 "@noble/hashes@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
+"@noble/hashes@1.3.3", "@noble/hashes@^1.3.3", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
@@ -183,6 +197,41 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-2.0.1.tgz#2aefdfa7eb5b7f29a7936978218e986c70c603fc"
   integrity sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==
 
+"@solana/buffer-layout@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz#b996235eaec15b1e0b5092a8ed6028df77fa6c15"
+  integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
+  dependencies:
+    buffer "~6.0.3"
+
+"@solana/web3.js@^1.91":
+  version "1.91.1"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.91.1.tgz#d49d2f982b52070be3b987fd8d892fcbddd064b5"
+  integrity sha512-cPgjZXm688oM9cULvJ8u2VH6Qp5rvptE1N1VODVxn2mAbpZsWrvWNPjmASkMYT/HzyrtqFkPvFdSHg8Xjt7aQA==
+  dependencies:
+    "@babel/runtime" "^7.23.4"
+    "@noble/curves" "^1.2.0"
+    "@noble/hashes" "^1.3.3"
+    "@solana/buffer-layout" "^4.0.1"
+    agentkeepalive "^4.5.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.2.1"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.1.0"
+    node-fetch "^2.7.0"
+    rpc-websockets "^7.5.1"
+    superstruct "^0.14.2"
+
+"@types/connect@^3.4.33":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookiejar@*":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
@@ -225,6 +274,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.7.tgz#8ccef136f240770c1379d50100796a6952f01f94"
   integrity sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==
 
+"@types/node@^12.12.54":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
 "@types/node@^18.13.0":
   version "18.16.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.0.tgz#4668bc392bb6938637b47e98b1f2ed5426f33316"
@@ -257,6 +311,13 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/ws@^7.4.4":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -268,6 +329,14 @@
   integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 abitype@0.9.8:
   version "0.9.8"
@@ -281,6 +350,13 @@ accepts@~1.3.8:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
+
+agentkeepalive@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.5.0.tgz#2673ad1389b3c418c5a20c5d7364f93ca04be923"
+  integrity sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -316,6 +392,18 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 basic-auth@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
@@ -323,10 +411,29 @@ basic-auth@~2.0.1:
   dependencies:
     safe-buffer "5.1.2"
 
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 blueimp-md5@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.19.0.tgz#b53feea5498dcb53dc6ec4b823adb84b729c4af0"
   integrity sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==
+
+bn.js@^5.2.0, bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.20.1, body-parser@^1.19.0:
   version "1.20.1"
@@ -346,6 +453,15 @@ body-parser@1.20.1, body-parser@^1.19.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+borsh@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.7.0.tgz#6e9560d719d86d90dc589bca60ffc8a6c51fec2a"
+  integrity sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==
+  dependencies:
+    bn.js "^5.2.0"
+    bs58 "^4.0.0"
+    text-encoding-utf-8 "^1.0.2"
+
 bowser@^2.4.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -357,6 +473,28 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+bs58@^4.0.0, bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
+buffer@6.0.3, buffer@~6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
+bufferutil@^4.0.1:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.8.tgz#1de6a71092d65d7766c4d8a522b261a6e787e8ea"
+  integrity sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -424,6 +562,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -485,6 +628,11 @@ debug@^4.1.0, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -528,6 +676,18 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -552,6 +712,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+eventemitter3@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 expect@^29.0.0:
   version "29.5.0"
@@ -601,6 +766,11 @@ express@^4.17.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+eyes@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
+
 fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -610,6 +780,16 @@ fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fast-stable-stringify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz#5c5543462b22aeeefd36d05b34e51c78cb86d313"
+  integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -738,12 +918,24 @@ http-graceful-shutdown@^3.1.5:
   dependencies:
     debug "^4.3.4"
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 inherits@2.0.4:
   version "2.0.4"
@@ -765,10 +957,33 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isows@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
   integrity sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==
+
+jayson@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-4.1.0.tgz#60dc946a85197317f2b1439d672a8b0a99cea2f9"
+  integrity sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==
+  dependencies:
+    "@types/connect" "^3.4.33"
+    "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
+    commander "^2.20.3"
+    delay "^5.0.0"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
+    json-stringify-safe "^5.0.1"
+    uuid "^8.3.2"
+    ws "^7.4.5"
 
 jest-diff@^29.5.0:
   version "29.5.0"
@@ -840,6 +1055,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 lodash-es@^4.17.21:
   version "4.17.21"
@@ -929,7 +1149,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.0.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -960,6 +1180,18 @@ node-fetch@^2.6.11:
   integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-gyp-build@^4.3.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
+  integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
 
 object-assign@^4:
   version "4.1.1"
@@ -1066,6 +1298,11 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -1076,12 +1313,25 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
+rpc-websockets@^7.5.1:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.9.0.tgz#a3938e16d6f134a3999fdfac422a503731bf8973"
+  integrity sha512-DwKewQz1IUA5wfLvgM8wDpPRcr+nWSxuFxx5CbrI2z/MyyZ4nXLM86TvIA+cI1ZAdqC8JIBR1mZR55dzaLU+Hw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    eventemitter3 "^4.0.7"
+    uuid "^8.3.2"
+    ws "^8.5.0"
+  optionalDependencies:
+    bufferutil "^4.0.1"
+    utf-8-validate "^5.0.2"
+
 safe-buffer@5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1184,6 +1434,11 @@ superagent@^8.0.5:
     qs "^6.11.0"
     semver "^7.3.8"
 
+superstruct@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
+  integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
+
 supertest@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
@@ -1205,6 +1460,16 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+text-encoding-utf-8@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
+  integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
+
+"through@>=2.2.7 <3":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1254,6 +1519,13 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+utf-8-validate@^5.0.2:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
+  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 utf8-byte-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
@@ -1263,6 +1535,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -1305,6 +1582,16 @@ ws@8.13.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
+ws@^7.4.5:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.5.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.17.2", "@babel/runtime@^7.23.4":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
+  integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -1649,6 +1656,13 @@
   dependencies:
     "@noble/hashes" "1.3.2"
 
+"@noble/curves@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
+  integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
+  dependencies:
+    "@noble/hashes" "1.3.3"
+
 "@noble/hashes@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
@@ -1659,7 +1673,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
+"@noble/hashes@1.3.3", "@noble/hashes@^1.3.3", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
@@ -2316,6 +2330,34 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@solana/buffer-layout@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz#b996235eaec15b1e0b5092a8ed6028df77fa6c15"
+  integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
+  dependencies:
+    buffer "~6.0.3"
+
+"@solana/web3.js@^1.91":
+  version "1.91.1"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.91.1.tgz#d49d2f982b52070be3b987fd8d892fcbddd064b5"
+  integrity sha512-cPgjZXm688oM9cULvJ8u2VH6Qp5rvptE1N1VODVxn2mAbpZsWrvWNPjmASkMYT/HzyrtqFkPvFdSHg8Xjt7aQA==
+  dependencies:
+    "@babel/runtime" "^7.23.4"
+    "@noble/curves" "^1.2.0"
+    "@noble/hashes" "^1.3.3"
+    "@solana/buffer-layout" "^4.0.1"
+    agentkeepalive "^4.5.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.2.1"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.1.0"
+    node-fetch "^2.7.0"
+    rpc-websockets "^7.5.1"
+    superstruct "^0.14.2"
+
 "@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz#74a5d648bd0347bda99d82409d87b8ca80b9a1ba"
@@ -2543,6 +2585,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/connect@^3.4.33":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookiejar@*":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
@@ -2722,6 +2771,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@^12.12.54":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -2895,6 +2949,13 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
+"@types/ws@^7.4.4":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ws@^8.5.1":
   version "8.5.4"
@@ -3188,6 +3249,14 @@
   dependencies:
     argparse "^2.0.1"
 
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
 abab@^2.0.5, abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -3245,6 +3314,13 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.5.0.tgz#2673ad1389b3c418c5a20c5d7364f93ca04be923"
+  integrity sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 ajv-formats@^2.1.1:
   version "2.1.1"
@@ -3679,6 +3755,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -3711,10 +3794,24 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bl@^4.0.3:
   version "4.1.0"
@@ -3735,7 +3832,7 @@ bn.js@^4.11.9:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.2.1:
+bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
@@ -3791,6 +3888,15 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+borsh@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.7.0.tgz#6e9560d719d86d90dc589bca60ffc8a6c51fec2a"
+  integrity sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==
+  dependencies:
+    bn.js "^5.2.0"
+    bs58 "^4.0.0"
+    text-encoding-utf-8 "^1.0.2"
+
 bowser@^2.4.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -3840,6 +3946,13 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
+bs58@^4.0.0, bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -3852,6 +3965,14 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer@6.0.3, buffer@~6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -3859,6 +3980,13 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+bufferutil@^4.0.1:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.8.tgz#1de6a71092d65d7766c4d8a522b261a6e787e8ea"
+  integrity sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 builtin-modules@^3.3.0:
   version "3.3.0"
@@ -4070,7 +4198,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4555,6 +4683,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -4888,6 +5021,18 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==
+  dependencies:
+    es6-promise "^4.0.3"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -5164,7 +5309,7 @@ ethers@^6.1.0:
     tslib "2.4.0"
     ws "8.5.0"
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.4:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5247,6 +5392,11 @@ express@^4.17.1, express@^4.17.3, express@~4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+eyes@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5288,6 +5438,11 @@ fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fast-stable-stringify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz#5c5543462b22aeeefd36d05b34e51c78cb86d313"
+  integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -5331,6 +5486,11 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.1:
   version "1.0.4"
@@ -5945,6 +6105,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
+
 husky@^8.0.0:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
@@ -5981,7 +6148,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -6340,6 +6507,11 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isows@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
@@ -6396,6 +6568,24 @@ jake@^10.8.5:
     chalk "^4.0.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
+
+jayson@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-4.1.0.tgz#60dc946a85197317f2b1439d672a8b0a99cea2f9"
+  integrity sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==
+  dependencies:
+    "@types/connect" "^3.4.33"
+    "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
+    commander "^2.20.3"
+    delay "^5.0.0"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
+    json-stringify-safe "^5.0.1"
+    uuid "^8.3.2"
+    ws "^7.4.5"
 
 jest-changed-files@^29.5.0:
   version "29.5.0"
@@ -6906,6 +7096,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
@@ -7324,7 +7519,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -7405,6 +7600,13 @@ node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -8454,6 +8656,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
+
 regenerator-transform@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.1.tgz#f6c4e99fc1b4591f780db2586328e4d9a9d8dc56"
@@ -8663,6 +8870,19 @@ route-recognizer@^0.3.4:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
   integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
+rpc-websockets@^7.5.1:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.9.0.tgz#a3938e16d6f134a3999fdfac422a503731bf8973"
+  integrity sha512-DwKewQz1IUA5wfLvgM8wDpPRcr+nWSxuFxx5CbrI2z/MyyZ4nXLM86TvIA+cI1ZAdqC8JIBR1mZR55dzaLU+Hw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    eventemitter3 "^4.0.7"
+    uuid "^8.3.2"
+    ws "^8.5.0"
+  optionalDependencies:
+    bufferutil "^4.0.1"
+    utf-8-validate "^5.0.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -8682,7 +8902,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -9256,6 +9476,11 @@ superagent@^8.0.5:
     qs "^6.11.0"
     semver "^7.3.8"
 
+superstruct@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
+  integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
+
 supertest@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
@@ -9376,6 +9601,11 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+text-encoding-utf-8@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
+  integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -9386,7 +9616,7 @@ throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
-through@^2.3.4:
+"through@>=2.2.7 <3", through@^2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
@@ -9714,6 +9944,13 @@ use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+utf-8-validate@^5.0.2:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
+  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 utf8-byte-length@^1.0.4:
   version "1.0.4"
@@ -10059,6 +10296,16 @@ ws@8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+
+ws@^7.4.5:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.5.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
```typescript
import { solanaWeb3, Solana } from "@quicknode/sdk";
const { Transaction, SystemProgram, Keypair, PublicKey } = solanaWeb3;

const mainSecretKey = Uint8Array.from([
//redacted
]);
const sender = Keypair.fromSecretKey(mainSecretKey);
const receiver = new PublicKey("redacted");
const senderPublicKey = sender.publicKey;

const endpoint = new Solana({
  endpointUrl:
    "https://some-cool-name.solana-mainnet.quiknode.pro/redacted",
});

const transaction = new Transaction();

// Add instructions for each receiver
transaction.add(
  SystemProgram.transfer({
    fromPubkey: senderPublicKey,
    toPubkey: receiver,
    lamports: 10,
  })
);

(async () => {
  // can use endpoint.connection, is @solana/web3js Connection
  // await endpoint.connection.sendTransaction(...)

  // Endpoint must added to Priority Fee API to do this
  const signature = await endpoint.sendSmartTransaction({
    transaction,
    keyPair: sender,
    feeLevel: "high"
  });
  console.log(signature);
})().catch(console.error);
```

If the user doesn't have the add-on installed:

![image](https://github.com/quiknode-labs/qn-oss/assets/5964462/37f4e73f-efb1-4805-b127-950c37f056ab)
