### PR TITLE
Update solana simulate error msg

### DIFF
--- a/packages/libs/sdk/src/solana/solana.ts
+++ b/packages/libs/sdk/src/solana/solana.ts
@@ -157,8 +157,11 @@ export class Solana {
       sigVerify: false,
     });
     if (simulation.value.err) {
-      console.error('Simulation error:', simulation.value.err);
-      throw new Error(`Failed to simulate transaction ${simulation.value.err}`);
+      const errorMsg =
+        typeof simulation.value.err === 'string'
+          ? simulation.value.err
+          : JSON.stringify(simulation.value.err);
+      throw new Error(`Failed to simulate transaction: ${errorMsg}`);
     }
     return simulation.value.unitsConsumed;
   }


### PR DESCRIPTION
`err` here is type `{} | string` so stringifying the error if it's not a string for better error delivery downstream (currently seeing this in some applications - "Failed to simulate transaction [object Object].")