### PR TITLE
fix: simulation error message

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",

--- a/packages/libs/sdk/src/lib/constants.ts
+++ b/packages/libs/sdk/src/lib/constants.ts
@@ -1,2 +1,2 @@
 // Ideally we read directly from package.json, but ran into some packaging issues with that
-export const PACKAGE_VERSION = '2.4.1';
+export const PACKAGE_VERSION = '2.4.2';

--- a/packages/libs/sdk/src/solana/solana.ts
+++ b/packages/libs/sdk/src/solana/solana.ts
@@ -162,7 +162,9 @@ export class Solana {
     });
     if (simulation.value.err) {
       console.error('Simulation error:', simulation.value.err);
-      throw new Error(`Failed to simulate transaction ${simulation.value.err}`);
+      throw new Error(
+        `Failed to simulate transaction ${JSON.stringify(simulation.value.err)}`
+      );
     }
     return simulation.value.unitsConsumed;
   }


### PR DESCRIPTION
Currently, this error message shows up as `Failed to simulate transaction [object Object]` when I use the `prepareSmartTransaction` method. This PR stringifies the simulation error so its readable