### PR TITLE
Version bump 2.5.2

### DIFF
--- a/packages/libs/sdk/package.json
+++ b/packages/libs/sdk/package.json
@@ -6,7 +6,7 @@
     "directory": "packages/libs/sdk"
   },
   "license": "MIT",
-  "version": "2.4.2",
+  "version": "2.5.2",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./index.d.ts",

--- a/packages/libs/sdk/src/lib/constants.ts
+++ b/packages/libs/sdk/src/lib/constants.ts
@@ -1,2 +1,2 @@
 // Ideally we read directly from package.json, but ran into some packaging issues with that
-export const PACKAGE_VERSION = '2.4.2';
+export const PACKAGE_VERSION = '2.5.2';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps @quicknode/sdk version to 2.5.2 and updates the `PACKAGE_VERSION` constant to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2db0ea657fa67cc2b98b9893d2613b6ae31d4108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->